### PR TITLE
Fix T-629: find --format json leaks non-matching descendants and can duplicate matches

### DIFF
--- a/internal/task/search.go
+++ b/internal/task/search.go
@@ -59,7 +59,11 @@ func (tl *TaskList) insertParents(results []Task) []Task {
 	for _, t := range results {
 		if t.ParentID != "" && !present[t.ParentID] {
 			if parent := tl.FindTask(t.ParentID); parent != nil {
-				out = append(out, *parent)
+				// Copy parent without Children to avoid leaking
+				// non-matching descendants into the result set.
+				p := *parent
+				p.Children = nil
+				out = append(out, p)
 				present[t.ParentID] = true
 			}
 		}
@@ -111,7 +115,14 @@ func (tl *TaskList) findInTasks(tasks []Task, pattern string, opts QueryOptions,
 		}
 
 		if found {
-			*results = append(*results, task)
+			// Copy the task without Children. The recursive walk below
+			// evaluates each child independently, so carrying the
+			// original Children slice would leak non-matching
+			// descendants into the result and duplicate children that
+			// match independently.
+			resultTask := task
+			resultTask.Children = nil
+			*results = append(*results, resultTask)
 		}
 
 		// Search in children recursively

--- a/internal/task/search_test.go
+++ b/internal/task/search_test.go
@@ -571,6 +571,227 @@ func TestTaskList_FindTask(t *testing.T) {
 	}
 }
 
+func TestTaskList_Find_ExcludesNonMatchingChildren(t *testing.T) {
+	tl := &TaskList{
+		Title:    "Test Project",
+		Modified: time.Now(),
+		Tasks: []Task{
+			{
+				ID:     "1",
+				Title:  "Parent matches search",
+				Status: Pending,
+				Children: []Task{
+					{
+						ID:       "1.1",
+						Title:    "Non-matching child",
+						Status:   Pending,
+						ParentID: "1",
+						Children: []Task{
+							{
+								ID:       "1.1.1",
+								Title:    "Non-matching grandchild",
+								Status:   Pending,
+								ParentID: "1.1",
+							},
+						},
+					},
+				},
+			},
+			{
+				ID:     "2",
+				Title:  "Another parent matches search",
+				Status: Pending,
+				Children: []Task{
+					{
+						ID:       "2.1",
+						Title:    "Child also matches search",
+						Status:   Pending,
+						ParentID: "2",
+						Children: []Task{
+							{
+								ID:       "2.1.1",
+								Title:    "Non-matching grandchild under matching child",
+								Status:   Pending,
+								ParentID: "2.1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := tl.Find("matches search", QueryOptions{})
+
+	// Should match: 1, 2, 2.1
+	gotIDs := extractTaskIDs(results)
+	wantIDs := []string{"1", "2", "2.1"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("Find() returned IDs = %v, want %v", gotIDs, wantIDs)
+	}
+
+	// Each result must have empty Children — non-matching descendants
+	// must not leak through (regression for T-629).
+	for _, task := range results {
+		if len(task.Children) != 0 {
+			childIDs := extractTaskIDs(task.Children)
+			t.Errorf("Find() result task %s has Children %v, want empty (non-matching descendants leaked)", task.ID, childIDs)
+		}
+	}
+}
+
+func TestTaskList_Find_NoDuplicateWhenChildAlsoMatches(t *testing.T) {
+	tl := &TaskList{
+		Title:    "Test Project",
+		Modified: time.Now(),
+		Tasks: []Task{
+			{
+				ID:     "1",
+				Title:  "Parent matches keyword",
+				Status: Pending,
+				Children: []Task{
+					{
+						ID:       "1.1",
+						Title:    "Child also matches keyword",
+						Status:   Pending,
+						ParentID: "1",
+					},
+				},
+			},
+		},
+	}
+
+	results := tl.Find("matches keyword", QueryOptions{})
+
+	gotIDs := extractTaskIDs(results)
+	wantIDs := []string{"1", "1.1"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("Find() returned IDs = %v, want %v", gotIDs, wantIDs)
+	}
+
+	// When both parent and child match, the child must NOT appear as a
+	// nested child under the parent AND again as a flat top-level result.
+	// The result list should be flat with no nested children.
+	for _, task := range results {
+		if len(task.Children) != 0 {
+			childIDs := extractTaskIDs(task.Children)
+			t.Errorf("Find() result task %s has Children %v, want empty (child duplicated as both nested and flat entry)", task.ID, childIDs)
+		}
+	}
+}
+
+func TestTaskList_Find_IncludeParent_ExcludesChildren(t *testing.T) {
+	tl := &TaskList{
+		Title:    "Test Project",
+		Modified: time.Now(),
+		Tasks: []Task{
+			{
+				ID:     "1",
+				Title:  "Parent task",
+				Status: Pending,
+				Children: []Task{
+					{
+						ID:       "1.1",
+						Title:    "Child matches target",
+						Status:   Pending,
+						ParentID: "1",
+						Children: []Task{
+							{
+								ID:       "1.1.1",
+								Title:    "Grandchild does not match",
+								Status:   Pending,
+								ParentID: "1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := tl.Find("target", QueryOptions{IncludeParent: true})
+
+	gotIDs := extractTaskIDs(results)
+	wantIDs := []string{"1", "1.1"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("Find() returned IDs = %v, want %v", gotIDs, wantIDs)
+	}
+
+	// Inserted parent tasks must also have empty Children — the parent
+	// inserted by IncludeParent must not carry its original Children.
+	for _, task := range results {
+		if len(task.Children) != 0 {
+			childIDs := extractTaskIDs(task.Children)
+			t.Errorf("Find() result task %s has Children %v, want empty", task.ID, childIDs)
+		}
+	}
+}
+
+func TestTaskList_Find_PreservesAllFields(t *testing.T) {
+	tl := &TaskList{
+		Title:    "Test Project",
+		Modified: time.Now(),
+		Tasks: []Task{
+			{
+				ID:           "1",
+				Title:        "Task matches keyword",
+				Status:       InProgress,
+				Details:      []string{"Some detail"},
+				References:   []string{"ref.md"},
+				Requirements: []string{"req-1"},
+				ParentID:     "",
+				StableID:     "stable-1",
+				BlockedBy:    []string{"dep-1"},
+				Stream:       2,
+				Owner:        "alice",
+				Children: []Task{
+					{
+						ID:       "1.1",
+						Title:    "Non-matching child",
+						Status:   Pending,
+						ParentID: "1",
+					},
+				},
+			},
+		},
+	}
+
+	results := tl.Find("keyword", QueryOptions{})
+	if len(results) != 1 {
+		t.Fatalf("Find() returned %d results, want 1", len(results))
+	}
+
+	got := results[0]
+	if got.ID != "1" || got.Title != "Task matches keyword" || got.Status != InProgress {
+		t.Errorf("Find() basic fields mismatch: %+v", got)
+	}
+	if !reflect.DeepEqual(got.Details, []string{"Some detail"}) {
+		t.Errorf("Find() Details = %v, want [Some detail]", got.Details)
+	}
+	if !reflect.DeepEqual(got.References, []string{"ref.md"}) {
+		t.Errorf("Find() References = %v, want [ref.md]", got.References)
+	}
+	if !reflect.DeepEqual(got.Requirements, []string{"req-1"}) {
+		t.Errorf("Find() Requirements = %v, want [req-1]", got.Requirements)
+	}
+	if got.StableID != "stable-1" {
+		t.Errorf("Find() StableID = %q, want %q", got.StableID, "stable-1")
+	}
+	if !reflect.DeepEqual(got.BlockedBy, []string{"dep-1"}) {
+		t.Errorf("Find() BlockedBy = %v, want [dep-1]", got.BlockedBy)
+	}
+	if got.Stream != 2 {
+		t.Errorf("Find() Stream = %d, want 2", got.Stream)
+	}
+	if got.Owner != "alice" {
+		t.Errorf("Find() Owner = %q, want %q", got.Owner, "alice")
+	}
+	// Children must be empty
+	if len(got.Children) != 0 {
+		t.Errorf("Find() Children = %v, want empty", got.Children)
+	}
+}
+
 func TestGetTaskDepth(t *testing.T) {
 	tests := map[string]struct {
 		taskID string

--- a/internal/task/search_test.go
+++ b/internal/task/search_test.go
@@ -571,200 +571,110 @@ func TestTaskList_FindTask(t *testing.T) {
 	}
 }
 
-func TestTaskList_Find_ExcludesNonMatchingChildren(t *testing.T) {
-	tl := &TaskList{
-		Title:    "Test Project",
-		Modified: time.Now(),
-		Tasks: []Task{
-			{
-				ID:     "1",
-				Title:  "Parent matches search",
-				Status: Pending,
-				Children: []Task{
-					{
-						ID:       "1.1",
-						Title:    "Non-matching child",
-						Status:   Pending,
-						ParentID: "1",
-						Children: []Task{
-							{
-								ID:       "1.1.1",
-								Title:    "Non-matching grandchild",
-								Status:   Pending,
-								ParentID: "1.1",
-							},
-						},
+// TestTaskList_Find_ChildrenStripped verifies that Find results never carry
+// nested Children, preventing JSON leaks of non-matching descendants and
+// duplicate entries (regression tests for T-629).
+func TestTaskList_Find_ChildrenStripped(t *testing.T) {
+	tests := map[string]struct {
+		tasks   []Task
+		pattern string
+		opts    QueryOptions
+		wantIDs []string
+	}{
+		"excludes_non_matching_children": {
+			tasks: []Task{
+				{
+					ID: "1", Title: "Parent matches search", Status: Pending,
+					Children: []Task{
+						{ID: "1.1", Title: "Non-matching child", Status: Pending, ParentID: "1",
+							Children: []Task{
+								{ID: "1.1.1", Title: "Non-matching grandchild", Status: Pending, ParentID: "1.1"},
+							}},
+					},
+				},
+				{
+					ID: "2", Title: "Another parent matches search", Status: Pending,
+					Children: []Task{
+						{ID: "2.1", Title: "Child also matches search", Status: Pending, ParentID: "2",
+							Children: []Task{
+								{ID: "2.1.1", Title: "Non-matching grandchild under matching child", Status: Pending, ParentID: "2.1"},
+							}},
 					},
 				},
 			},
-			{
-				ID:     "2",
-				Title:  "Another parent matches search",
-				Status: Pending,
-				Children: []Task{
-					{
-						ID:       "2.1",
-						Title:    "Child also matches search",
-						Status:   Pending,
-						ParentID: "2",
-						Children: []Task{
-							{
-								ID:       "2.1.1",
-								Title:    "Non-matching grandchild under matching child",
-								Status:   Pending,
-								ParentID: "2.1",
-							},
-						},
+			pattern: "matches search",
+			opts:    QueryOptions{},
+			wantIDs: []string{"1", "2", "2.1"},
+		},
+		"no_duplicate_when_child_also_matches": {
+			tasks: []Task{
+				{
+					ID: "1", Title: "Parent matches keyword", Status: Pending,
+					Children: []Task{
+						{ID: "1.1", Title: "Child also matches keyword", Status: Pending, ParentID: "1"},
 					},
 				},
 			},
+			pattern: "matches keyword",
+			opts:    QueryOptions{},
+			wantIDs: []string{"1", "1.1"},
+		},
+		"include_parent_excludes_children": {
+			tasks: []Task{
+				{
+					ID: "1", Title: "Parent task", Status: Pending,
+					Children: []Task{
+						{ID: "1.1", Title: "Child matches target", Status: Pending, ParentID: "1",
+							Children: []Task{
+								{ID: "1.1.1", Title: "Grandchild does not match", Status: Pending, ParentID: "1.1"},
+							}},
+					},
+				},
+			},
+			pattern: "target",
+			opts:    QueryOptions{IncludeParent: true},
+			wantIDs: []string{"1", "1.1"},
+		},
+		"preserves_all_non_children_fields": {
+			tasks: []Task{
+				{
+					ID: "1", Title: "Task matches keyword", Status: InProgress,
+					Details: []string{"Some detail"}, References: []string{"ref.md"},
+					Requirements: []string{"req-1"}, StableID: "stable-1",
+					BlockedBy: []string{"dep-1"}, Stream: 2, Owner: "alice",
+					Children: []Task{
+						{ID: "1.1", Title: "Non-matching child", Status: Pending, ParentID: "1"},
+					},
+				},
+			},
+			pattern: "keyword",
+			opts:    QueryOptions{},
+			wantIDs: []string{"1"},
 		},
 	}
 
-	results := tl.Find("matches search", QueryOptions{})
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tl := &TaskList{Title: "Test", Modified: time.Now(), Tasks: tc.tasks}
+			results := tl.Find(tc.pattern, tc.opts)
 
-	// Should match: 1, 2, 2.1
-	gotIDs := extractTaskIDs(results)
-	wantIDs := []string{"1", "2", "2.1"}
-	if !reflect.DeepEqual(gotIDs, wantIDs) {
-		t.Fatalf("Find() returned IDs = %v, want %v", gotIDs, wantIDs)
+			gotIDs := extractTaskIDs(results)
+			if !reflect.DeepEqual(gotIDs, tc.wantIDs) {
+				t.Fatalf("Find() returned IDs = %v, want %v", gotIDs, tc.wantIDs)
+			}
+
+			for _, task := range results {
+				if len(task.Children) != 0 {
+					childIDs := extractTaskIDs(task.Children)
+					t.Errorf("Find() result task %s has Children %v, want empty", task.ID, childIDs)
+				}
+			}
+		})
 	}
 
-	// Each result must have empty Children — non-matching descendants
-	// must not leak through (regression for T-629).
-	for _, task := range results {
-		if len(task.Children) != 0 {
-			childIDs := extractTaskIDs(task.Children)
-			t.Errorf("Find() result task %s has Children %v, want empty (non-matching descendants leaked)", task.ID, childIDs)
-		}
-	}
-}
-
-func TestTaskList_Find_NoDuplicateWhenChildAlsoMatches(t *testing.T) {
-	tl := &TaskList{
-		Title:    "Test Project",
-		Modified: time.Now(),
-		Tasks: []Task{
-			{
-				ID:     "1",
-				Title:  "Parent matches keyword",
-				Status: Pending,
-				Children: []Task{
-					{
-						ID:       "1.1",
-						Title:    "Child also matches keyword",
-						Status:   Pending,
-						ParentID: "1",
-					},
-				},
-			},
-		},
-	}
-
-	results := tl.Find("matches keyword", QueryOptions{})
-
-	gotIDs := extractTaskIDs(results)
-	wantIDs := []string{"1", "1.1"}
-	if !reflect.DeepEqual(gotIDs, wantIDs) {
-		t.Fatalf("Find() returned IDs = %v, want %v", gotIDs, wantIDs)
-	}
-
-	// When both parent and child match, the child must NOT appear as a
-	// nested child under the parent AND again as a flat top-level result.
-	// The result list should be flat with no nested children.
-	for _, task := range results {
-		if len(task.Children) != 0 {
-			childIDs := extractTaskIDs(task.Children)
-			t.Errorf("Find() result task %s has Children %v, want empty (child duplicated as both nested and flat entry)", task.ID, childIDs)
-		}
-	}
-}
-
-func TestTaskList_Find_IncludeParent_ExcludesChildren(t *testing.T) {
-	tl := &TaskList{
-		Title:    "Test Project",
-		Modified: time.Now(),
-		Tasks: []Task{
-			{
-				ID:     "1",
-				Title:  "Parent task",
-				Status: Pending,
-				Children: []Task{
-					{
-						ID:       "1.1",
-						Title:    "Child matches target",
-						Status:   Pending,
-						ParentID: "1",
-						Children: []Task{
-							{
-								ID:       "1.1.1",
-								Title:    "Grandchild does not match",
-								Status:   Pending,
-								ParentID: "1.1",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	results := tl.Find("target", QueryOptions{IncludeParent: true})
-
-	gotIDs := extractTaskIDs(results)
-	wantIDs := []string{"1", "1.1"}
-	if !reflect.DeepEqual(gotIDs, wantIDs) {
-		t.Fatalf("Find() returned IDs = %v, want %v", gotIDs, wantIDs)
-	}
-
-	// Inserted parent tasks must also have empty Children — the parent
-	// inserted by IncludeParent must not carry its original Children.
-	for _, task := range results {
-		if len(task.Children) != 0 {
-			childIDs := extractTaskIDs(task.Children)
-			t.Errorf("Find() result task %s has Children %v, want empty", task.ID, childIDs)
-		}
-	}
-}
-
-func TestTaskList_Find_PreservesAllFields(t *testing.T) {
-	tl := &TaskList{
-		Title:    "Test Project",
-		Modified: time.Now(),
-		Tasks: []Task{
-			{
-				ID:           "1",
-				Title:        "Task matches keyword",
-				Status:       InProgress,
-				Details:      []string{"Some detail"},
-				References:   []string{"ref.md"},
-				Requirements: []string{"req-1"},
-				ParentID:     "",
-				StableID:     "stable-1",
-				BlockedBy:    []string{"dep-1"},
-				Stream:       2,
-				Owner:        "alice",
-				Children: []Task{
-					{
-						ID:       "1.1",
-						Title:    "Non-matching child",
-						Status:   Pending,
-						ParentID: "1",
-					},
-				},
-			},
-		},
-	}
-
-	results := tl.Find("keyword", QueryOptions{})
-	if len(results) != 1 {
-		t.Fatalf("Find() returned %d results, want 1", len(results))
-	}
-
-	got := results[0]
-	if got.ID != "1" || got.Title != "Task matches keyword" || got.Status != InProgress {
-		t.Errorf("Find() basic fields mismatch: %+v", got)
-	}
+	// Extra field-preservation checks for the "preserves_all_non_children_fields" case.
+	tl := &TaskList{Title: "Test", Modified: time.Now(), Tasks: tests["preserves_all_non_children_fields"].tasks}
+	got := tl.Find("keyword", QueryOptions{})[0]
 	if !reflect.DeepEqual(got.Details, []string{"Some detail"}) {
 		t.Errorf("Find() Details = %v, want [Some detail]", got.Details)
 	}
@@ -786,9 +696,51 @@ func TestTaskList_Find_PreservesAllFields(t *testing.T) {
 	if got.Owner != "alice" {
 		t.Errorf("Find() Owner = %q, want %q", got.Owner, "alice")
 	}
-	// Children must be empty
+}
+
+// TestTaskList_Filter_PreservesAllFields verifies that Filter results retain
+// all task fields (not just the subset from the original struct-literal copy).
+func TestTaskList_Filter_PreservesAllFields(t *testing.T) {
+	tl := &TaskList{
+		Title:    "Test Project",
+		Modified: time.Now(),
+		Tasks: []Task{
+			{
+				ID: "1", Title: "Task one", Status: InProgress,
+				Details: []string{"detail"}, References: []string{"ref.md"},
+				Requirements: []string{"req-1"}, StableID: "stable-1",
+				BlockedBy: []string{"dep-1"}, Stream: 3, Owner: "bob",
+				Children: []Task{
+					{ID: "1.1", Title: "Child", Status: Pending, ParentID: "1"},
+				},
+			},
+		},
+	}
+
+	inProgress := InProgress
+	results := tl.Filter(QueryFilter{Status: &inProgress})
+	if len(results) != 1 {
+		t.Fatalf("Filter() returned %d results, want 1", len(results))
+	}
+
+	got := results[0]
+	if !reflect.DeepEqual(got.Requirements, []string{"req-1"}) {
+		t.Errorf("Filter() Requirements = %v, want [req-1]", got.Requirements)
+	}
+	if got.StableID != "stable-1" {
+		t.Errorf("Filter() StableID = %q, want %q", got.StableID, "stable-1")
+	}
+	if !reflect.DeepEqual(got.BlockedBy, []string{"dep-1"}) {
+		t.Errorf("Filter() BlockedBy = %v, want [dep-1]", got.BlockedBy)
+	}
+	if got.Stream != 3 {
+		t.Errorf("Filter() Stream = %d, want 3", got.Stream)
+	}
+	if got.Owner != "bob" {
+		t.Errorf("Filter() Owner = %q, want %q", got.Owner, "bob")
+	}
 	if len(got.Children) != 0 {
-		t.Errorf("Find() Children = %v, want empty", got.Children)
+		t.Errorf("Filter() Children should be empty, got %v", got.Children)
 	}
 }
 

--- a/specs/bugfixes/find-json-leaks-descendants/report.md
+++ b/specs/bugfixes/find-json-leaks-descendants/report.md
@@ -1,0 +1,79 @@
+# Bugfix Report: find-json-leaks-descendants
+
+**Date:** 2026-03-30
+**Status:** Fixed
+
+## Description of the Issue
+
+`find --format json` leaked non-matching descendant tasks into JSON output and could duplicate tasks that matched independently as both nested children and top-level results.
+
+**Reproduction steps:**
+1. Create a task file where task 1 title matches a pattern but task 1.1 does not
+2. Run `rune find <file> --pattern <parent-term> --format json`
+3. Observe that task 1.1 appears in JSON output under task 1's children despite not matching
+
+**Impact:** JSON consumers received incorrect search results — non-matching tasks appeared in output and matching children were duplicated.
+
+## Investigation Summary
+
+- **Symptoms examined:** JSON output contained full nested hierarchies for matched tasks instead of flat matching-only results
+- **Code inspected:** `internal/task/search.go` (`findInTasks`, `insertParents`), `cmd/find.go` (`outputSearchResultsJSON`), `internal/task/render.go` (`RenderJSON`, `toJSONTask`)
+- **Hypotheses tested:** Compared `Find` behavior with `Filter` — Filter correctly strips Children, Find did not
+
+## Discovered Root Cause
+
+**Defect type:** Logic error — missing data sanitization before output
+
+**Why it occurred:** `findInTasks` appended matched tasks with their full `Children` slices intact (line 114). When `RenderJSON` processed these results via `toJSONTask`, it recursively serialized all nested children regardless of whether they matched the search pattern. Similarly, `insertParents` spliced in parent tasks from `FindTask` with full children.
+
+**Contributing factors:** The `Filter` function already had the correct pattern (copying tasks without Children), but `Find` was written independently and didn't follow the same approach. No tests verified that Find results had empty Children slices.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/search.go:113-120` - Copy matched task and nil out Children before appending to results
+- `internal/task/search.go:58-67` - Copy parent task and nil out Children in `insertParents`
+
+**Approach rationale:** Matches the established pattern from `filterTasks` — the recursive walk evaluates each child independently, so carrying the original Children slice is unnecessary and harmful.
+
+**Alternatives considered:**
+- Stripping children in `outputSearchResultsJSON` (cmd layer) — rejected because the bug is in the data layer and would leave other callers affected
+- Creating a dedicated search-result JSON type — over-engineered for this fix
+
+## Regression Test
+
+**Test file:** `internal/task/search_test.go`
+**Test names:**
+- `TestTaskList_Find_ExcludesNonMatchingChildren`
+- `TestTaskList_Find_NoDuplicateWhenChildAlsoMatches`
+- `TestTaskList_Find_IncludeParent_ExcludesChildren`
+- `TestTaskList_Find_PreservesAllFields`
+
+**What they verify:** Matched tasks have empty Children slices, no duplication when parent and child both match, inserted parents also have empty Children, and all non-Children fields are preserved.
+
+**Run command:** `go test -run "TestTaskList_Find_Excludes|TestTaskList_Find_NoDuplicate|TestTaskList_Find_IncludeParent_Excludes|TestTaskList_Find_PreservesAllFields" -v ./internal/task/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/search.go` | Strip Children from matched tasks in `findInTasks` and inserted parents in `insertParents` |
+| `internal/task/search_test.go` | Add 4 regression tests verifying Children are excluded from Find results |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] Code formatted with `make fmt`
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When returning task subsets, always strip Children to produce flat result lists — the recursive walk handles child evaluation independently
+- Follow the established pattern in `filterTasks` for any new search/query functions
+
+## Related
+
+- Transit ticket: T-629
+- Similar fix pattern: `filterTasks` in `internal/task/search.go` (lines 165-178)


### PR DESCRIPTION
## Bug

`find --format json` leaked non-matching descendant tasks into JSON output and could duplicate tasks that matched independently as both nested children and top-level results.

## Root Cause

`findInTasks` in `internal/task/search.go` appended matched tasks with their full `Children` slices intact. When `RenderJSON` processed these results, it recursively serialized all nested children regardless of whether they matched the search pattern. Similarly, `insertParents` spliced in parent tasks with full children.

## Fix

Strip `Children` from matched tasks before appending to results (same pattern already used by `filterTasks`). Also strip Children from parents inserted by `insertParents`.

## Testing

- 4 new regression tests covering all aspects of the bug
- Full test suite passes with no regressions

See `specs/bugfixes/find-json-leaks-descendants/report.md` for the full bugfix report.

Fixes T-629