### PR TITLE
Fix T-655: has-phases counts YAML front matter headings as phases

### DIFF
--- a/cmd/has_phases.go
+++ b/cmd/has_phases.go
@@ -63,8 +63,9 @@ func runHasPhases(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s", errMsg)
 	}
 
-	// Extract phase markers
-	lines := strings.Split(string(content), "\n")
+	// Extract phase markers, stripping front matter first so YAML
+	// content (which may contain "## " lines) is not counted as phases.
+	lines := task.StripFrontMatterLines(strings.Split(string(content), "\n"))
 	markers := task.ExtractPhaseMarkers(lines)
 
 	// Build result

--- a/cmd/has_phases_test.go
+++ b/cmd/has_phases_test.go
@@ -92,6 +92,41 @@ func TestHasPhasesDetection(t *testing.T) {
 			wantCount:     0,
 			wantPhases:    []string{},
 		},
+		"front_matter_with_h2_no_real_phases": {
+			content: `---
+note: |
+  ## not-a-phase
+---
+- [ ] 1. Task`,
+			wantHasPhases: false,
+			wantCount:     0,
+			wantPhases:    []string{},
+		},
+		"front_matter_with_h2_and_real_phases": {
+			content: `---
+note: |
+  ## not-a-phase
+---
+# Tasks
+
+## Real Phase
+- [ ] 1. Task`,
+			wantHasPhases: true,
+			wantCount:     1,
+			wantPhases:    []string{"Real Phase"},
+		},
+		"front_matter_with_multiple_h2_lines": {
+			content: `---
+## heading-in-yaml
+## another-heading
+metadata:
+  key: value
+---
+- [ ] 1. Task`,
+			wantHasPhases: false,
+			wantCount:     0,
+			wantPhases:    []string{},
+		},
 		"file_with_special_characters_in_phase": {
 			content: `## Phase-1: Setup & Config
 - [ ] 1. Task`,
@@ -103,8 +138,8 @@ func TestHasPhasesDetection(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Test using ExtractPhaseMarkers directly
-			lines := strings.Split(tc.content, "\n")
+			// Test using StripFrontMatterLines + ExtractPhaseMarkers (matching command behavior)
+			lines := task.StripFrontMatterLines(strings.Split(tc.content, "\n"))
 			markers := task.ExtractPhaseMarkers(lines)
 
 			hasPhases := len(markers) > 0
@@ -179,7 +214,7 @@ func TestHasPhasesCommandOutput(t *testing.T) {
 			}
 
 			// Test the output structure
-			lines := strings.Split(tc.content, "\n")
+			lines := task.StripFrontMatterLines(strings.Split(tc.content, "\n"))
 			markers := task.ExtractPhaseMarkers(lines)
 
 			result := HasPhasesOutput{
@@ -254,7 +289,7 @@ func TestHasPhasesWithMalformedFile(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			lines := strings.Split(tc.content, "\n")
+			lines := task.StripFrontMatterLines(strings.Split(tc.content, "\n"))
 			markers := task.ExtractPhaseMarkers(lines)
 
 			hasPhases := len(markers) > 0

--- a/internal/task/parse.go
+++ b/internal/task/parse.go
@@ -75,18 +75,18 @@ func ParseFileWithPhases(filepath string) (*TaskList, []PhaseMarker, error) {
 	taskList.FilePath = filepath
 
 	// Extract phase markers from the content, stripping front matter first
-	lines := stripFrontMatterLines(splitLines(string(content)))
+	lines := StripFrontMatterLines(splitLines(string(content)))
 
 	phaseMarkers := ExtractPhaseMarkers(lines)
 
 	return taskList, phaseMarkers, nil
 }
 
-// stripFrontMatterLines removes front matter lines from the beginning of a
+// StripFrontMatterLines removes front matter lines from the beginning of a
 // file's line array. Front matter is delimited by exactly two "---" lines at
 // the start of the file. Only the initial pair of delimiters is consumed;
 // any later "---" lines (horizontal rules) are preserved.
-func stripFrontMatterLines(lines []string) []string {
+func StripFrontMatterLines(lines []string) []string {
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) != frontMatterDelimiter {
 		return lines
 	}

--- a/internal/task/parse_phases_frontmatter_test.go
+++ b/internal/task/parse_phases_frontmatter_test.go
@@ -222,7 +222,7 @@ func TestFrontMatterStrippingForPhaseExtraction(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			lines := stripFrontMatterLines(strings.Split(tc.rawContent, "\n"))
+			lines := StripFrontMatterLines(strings.Split(tc.rawContent, "\n"))
 			markers := ExtractPhaseMarkers(lines)
 
 			if !reflect.DeepEqual(markers, tc.wantPhases) {

--- a/specs/bugfixes/has-phases-front-matter-headings/report.md
+++ b/specs/bugfixes/has-phases-front-matter-headings/report.md
@@ -1,0 +1,87 @@
+# Bugfix Report: has-phases-front-matter-headings
+
+**Date:** 2026-03-30
+**Status:** Fixed
+**Ticket:** T-655
+
+## Description of the Issue
+
+`rune has-phases` incorrectly reported files with YAML front matter as containing phases when the front matter contained lines starting with `## ` (H2 markdown heading syntax).
+
+**Reproduction steps:**
+1. Create a task file with YAML front matter containing a `## ` line (e.g., `## not-a-phase` inside a YAML block scalar)
+2. Run `rune has-phases <file>`
+3. Observe `hasPhases: true` and non-zero phase count despite no real phase headers in the task content
+
+**Impact:** Any file with YAML front matter containing `## ` patterns would be misidentified as having phases, causing incorrect behaviour in scripts and agents relying on `has-phases` for phase detection.
+
+## Investigation Summary
+
+- **Symptoms examined:** `has-phases` returns `hasPhases: true` for files where front matter YAML contains H2-like lines
+- **Code inspected:** `cmd/has_phases.go`, `internal/task/parse.go` (both `ParseFileWithPhases` and `ExtractPhaseMarkers`)
+- **Hypotheses tested:** Compared `has_phases.go` code path with `ParseFileWithPhases` — confirmed the latter correctly strips front matter while the former does not
+
+## Discovered Root Cause
+
+`cmd/has_phases.go` reads the file, splits it into lines, and passes those lines directly to `task.ExtractPhaseMarkers()` without stripping YAML front matter. Meanwhile, `ParseFileWithPhases()` correctly calls `stripFrontMatterLines()` before extracting phase markers.
+
+**Defect type:** Missing input sanitisation — inconsistent code path
+
+**Why it occurred:** The `has-phases` command was implemented independently from `ParseFileWithPhases` and did not reuse the front-matter stripping logic already present in the parsing pipeline.
+
+**Contributing factors:** `stripFrontMatterLines` was unexported, making it less discoverable for reuse by the command layer.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/parse.go:85` — Exported `stripFrontMatterLines` → `StripFrontMatterLines` for reuse by the command layer
+- `cmd/has_phases.go:66-68` — Added `task.StripFrontMatterLines()` call before `ExtractPhaseMarkers()`
+
+**Approach rationale:** Reuses the existing, tested front-matter stripping function rather than duplicating logic. Exporting the function makes it available to any future consumers.
+
+**Alternatives considered:**
+- Calling `ParseFileWithPhases()` instead — rejected because it parses the full TaskList unnecessarily
+- Duplicating front-matter stripping inline — rejected to avoid code duplication
+
+## Regression Test
+
+**Test file:** `cmd/has_phases_test.go`
+**Test names:**
+- `TestHasPhasesDetection/front_matter_with_h2_no_real_phases`
+- `TestHasPhasesDetection/front_matter_with_h2_and_real_phases`
+- `TestHasPhasesDetection/front_matter_with_multiple_h2_lines`
+
+**What it verifies:** H2-like lines inside YAML front matter are not counted as phases; real phases after front matter are still detected correctly.
+
+**Run command:** `go test -run TestHasPhasesDetection/front_matter -v ./cmd`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/parse.go` | Exported `StripFrontMatterLines` |
+| `internal/task/parse_phases_frontmatter_test.go` | Updated call to use exported name |
+| `cmd/has_phases.go` | Strip front matter before phase extraction |
+| `cmd/has_phases_test.go` | Added 3 regression test cases; updated all tests to use `StripFrontMatterLines` |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`make test`)
+- [x] Manual validation confirms fix
+
+**Manual verification:**
+- Created file with front matter containing `## not-a-phase`, confirmed `has-phases` returns `false`
+- Verified files with real phases after front matter still report correctly
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding commands that operate on file content, always strip front matter first — reuse `StripFrontMatterLines`
+- Keep utility functions exported when they represent reusable file-processing steps
+
+## Related
+
+- T-458: Previous fix for `ParseFileWithPhases` front-matter/horizontal-rule interaction
+- `specs/bugfixes/parse-file-with-phases-front-matter-hr/` — Related earlier bugfix


### PR DESCRIPTION
## Bug

`rune has-phases` incorrectly counted lines starting with `## ` inside YAML front matter as phase headers.

## Root Cause

`cmd/has_phases.go` passed raw file content (including front matter) directly to `ExtractPhaseMarkers()`, unlike `ParseFileWithPhases()` which correctly strips front matter first via `stripFrontMatterLines()`.

## Fix

- Exported `StripFrontMatterLines` from `internal/task/parse.go` for reuse
- Added `task.StripFrontMatterLines()` call in `has_phases.go` before `ExtractPhaseMarkers()`
- Added 3 regression tests covering front matter with H2-like lines

## Verification

- All unit tests pass (`make test`)
- Manual validation confirms fix
- See `specs/bugfixes/has-phases-front-matter-headings/report.md` for full report