### PR TITLE
Fix T-637: next --phase --claim claims all ready tasks from next phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Next Command**: `next --phase --claim AGENT` now correctly claims all ready tasks from the next phase instead of silently ignoring `--phase` and claiming only a single task
 - **Phase Parsing**: `ParseFileWithPhases` front-matter stripping no longer treats horizontal rules (`---`) after front matter as additional front-matter delimiters, which would cause phase markers after the rule to be silently dropped
 - **Phase Parsing**: Normalize CRLF line endings in all phase-related functions (`ParseFileWithPhases`, `ExtractPhaseMarkers`, `getTaskPhase`, `getNextPhaseTasks`, `FindNextPhaseTasks`, `FindNextPhaseTasksForStream`, and phase-aware operations) by introducing a `splitLines` helper that trims `\r` after splitting on `\n`
 - **Find Command**: `--parent ""` now correctly filters to top-level tasks; previously the empty string was indistinguishable from the flag's default, causing the filter to be skipped

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -207,6 +207,24 @@ func runNextWithClaim(filename string) error {
 				taskIDsToClaim = append(taskIDsToClaim, t.ID)
 			}
 		}
+	case phaseFlag:
+		// Handle --phase --claim combination (no stream)
+		phaseResult, err := task.FindNextPhaseTasks(filename)
+		if err != nil {
+			return fmt.Errorf("failed to find next phase tasks: %w", err)
+		}
+
+		if phaseResult == nil {
+			return outputClaimEmpty(0)
+		}
+
+		// Filter to only ready tasks (pending, no owner, not blocked)
+		for i := range phaseResult.Tasks {
+			t := &phaseResult.Tasks[i]
+			if isTaskReady(t, index) {
+				taskIDsToClaim = append(taskIDsToClaim, t.ID)
+			}
+		}
 	case streamFlag > 0:
 		// Claim all ready tasks in the specified stream (flat — readyTasks is already flattened)
 		readyTasks := getReadyTasks(taskList.Tasks, index)

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -2363,3 +2363,170 @@ func TestNextCommandOneWithClaimFallsBackToReadyTask(t *testing.T) {
 		t.Errorf("expected task 1.2 to be in-progress in file, got: %s", fileStr)
 	}
 }
+
+// TestNextCommandPhaseClaimClaimsAllReadyTasksInPhase verifies that
+// --phase --claim claims ALL ready tasks from the next phase, not just one.
+// Regression test for T-637.
+func TestNextCommandPhaseClaimClaimsAllReadyTasksInPhase(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "rune-next-phase-claim-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	// Reset flags
+	streamFlag = 0
+	claimFlag = ""
+	phaseFlag = false
+	oneFlag = false
+
+	const taskFile = "phase-claim.md"
+	content := `# Project Tasks
+
+## Phase 1
+- [ ] 1. First ready task
+- [ ] 2. Second ready task
+- [ ] 3. Third ready task
+
+## Phase 2
+- [ ] 4. Later phase task
+`
+
+	if err := os.WriteFile(taskFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{"next", taskFile, "--phase", "--claim", "agent-a", "--format", "json"})
+	err = rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	rootCmd.SetArgs([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should claim all 3 ready tasks from Phase 1, not just the first one
+	if !strings.Contains(output, `"count": 3`) {
+		t.Errorf("expected 3 tasks claimed from phase, got: %s", output)
+	}
+	if !strings.Contains(output, `"id": "1"`) {
+		t.Errorf("expected task 1 in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"id": "2"`) {
+		t.Errorf("expected task 2 in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"id": "3"`) {
+		t.Errorf("expected task 3 in output, got: %s", output)
+	}
+	// Task from Phase 2 should NOT be claimed
+	if strings.Contains(output, `"id": "4"`) {
+		t.Errorf("task 4 from Phase 2 should not be claimed, got: %s", output)
+	}
+
+	// Verify file was updated — all Phase 1 tasks should be in-progress with owner
+	fileContent, err := os.ReadFile(taskFile)
+	if err != nil {
+		t.Fatalf("failed to read file after claim: %v", err)
+	}
+	fileStr := string(fileContent)
+
+	if !strings.Contains(fileStr, "[-] 1.") {
+		t.Errorf("expected task 1 to be in-progress in file, got: %s", fileStr)
+	}
+	if !strings.Contains(fileStr, "[-] 2.") {
+		t.Errorf("expected task 2 to be in-progress in file, got: %s", fileStr)
+	}
+	if !strings.Contains(fileStr, "[-] 3.") {
+		t.Errorf("expected task 3 to be in-progress in file, got: %s", fileStr)
+	}
+	// Phase 2 task should remain pending
+	if strings.Contains(fileStr, "[-] 4.") {
+		t.Errorf("task 4 from Phase 2 should remain pending, got: %s", fileStr)
+	}
+}
+
+// TestNextCommandPhaseClaimExcludesBlockedTasks verifies that
+// --phase --claim skips blocked tasks within the phase.
+// Regression test for T-637.
+func TestNextCommandPhaseClaimExcludesBlockedTasks(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "rune-next-phase-claim-blocked-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	// Reset flags
+	streamFlag = 0
+	claimFlag = ""
+	phaseFlag = false
+	oneFlag = false
+
+	const taskFile = "phase-claim-blocked.md"
+	content := `# Project Tasks
+
+## Phase 1
+- [ ] 1. Ready task A <!-- id:aaa0001 -->
+- [ ] 2. Ready task B <!-- id:bbb0002 -->
+- [ ] 3. Blocked task <!-- id:ccc0003 -->
+  - Blocked-by: aaa0001 (Ready task A)
+
+## Phase 2
+- [ ] 4. Later phase task
+`
+
+	if err := os.WriteFile(taskFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{"next", taskFile, "--phase", "--claim", "agent-b", "--format", "json"})
+	err = rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	rootCmd.SetArgs([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should claim only the 2 ready (non-blocked) tasks from Phase 1
+	if !strings.Contains(output, `"count": 2`) {
+		t.Errorf("expected 2 tasks claimed (excluding blocked), got: %s", output)
+	}
+	if !strings.Contains(output, `"id": "1"`) {
+		t.Errorf("expected task 1 in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"id": "2"`) {
+		t.Errorf("expected task 2 in output, got: %s", output)
+	}
+	// Blocked task 3 should NOT be claimed
+	if strings.Contains(output, `"id": "3"`) {
+		t.Errorf("blocked task 3 should not be claimed, got: %s", output)
+	}
+}

--- a/specs/bugfixes/next-phase-claim/report.md
+++ b/specs/bugfixes/next-phase-claim/report.md
@@ -1,0 +1,79 @@
+# Bugfix Report: next-phase-claim
+
+**Date:** 2026-03-30
+**Status:** Fixed
+
+## Description of the Issue
+
+Running `rune next --phase --claim AGENT` ignored the `--phase` flag and claimed only a single ready task instead of all ready tasks from the next phase.
+
+**Reproduction steps:**
+1. Create a task file with phases where the first phase has multiple ready tasks.
+2. Run `rune next tasks.md --phase --claim agent-a`.
+3. Observe only one task is claimed instead of all ready tasks from the next phase.
+
+**Impact:** Agents using `--phase --claim` to batch-claim phase work received only one task, requiring repeated invocations and defeating the purpose of phase-based claiming.
+
+## Investigation Summary
+
+- **Symptoms examined:** `--phase --claim` with no `--stream` claimed exactly one task
+- **Code inspected:** `cmd/next.go` — `runNextWithClaim()` switch statement (lines 191–240)
+- **Hypotheses tested:** The switch statement had cases for `phaseFlag && streamFlag > 0`, `streamFlag > 0`, and a default — but no case for `phaseFlag` alone
+
+## Discovered Root Cause
+
+**Defect type:** Missing switch case (logic gap)
+
+**Why it occurred:** The `runNextWithClaim` switch statement handled `--phase --stream --claim` and `--stream --claim`, but had no case for `--phase --claim` (without `--stream`). When `phaseFlag=true` and `streamFlag=0`, neither the first case (`phaseFlag && streamFlag > 0` → false) nor the second (`streamFlag > 0` → false) matched, so execution fell through to the `default` case which claims only the single first ready task.
+
+**Contributing factors:** The `runNextPhase()` function (non-claim path) correctly handled `--phase` without `--stream`, but the claim path was not updated to mirror this when claim support was added.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/next.go:210-225` — Added `case phaseFlag:` between the `phaseFlag && streamFlag > 0` case and the `streamFlag > 0` case. This new case calls `task.FindNextPhaseTasks(filename)` to discover all pending tasks in the next phase, then filters to ready tasks using `isTaskReady`, matching the pattern used by the phase+stream case.
+
+**Approach rationale:** Mirrors the existing `phaseFlag && streamFlag > 0` case structure but uses `FindNextPhaseTasks` (the non-stream variant), consistent with how `runNextPhase` handles the same flag combination in the non-claim path.
+
+**Alternatives considered:**
+- Refactoring the switch into if/else with shared phase resolution — rejected as higher risk for a targeted fix
+
+## Regression Test
+
+**Test file:** `cmd/next_test.go`
+**Test names:**
+- `TestNextCommandPhaseClaimClaimsAllReadyTasksInPhase`
+- `TestNextCommandPhaseClaimExcludesBlockedTasks`
+
+**What they verify:**
+1. `--phase --claim` claims ALL ready tasks from the first phase (3 tasks), not just one
+2. `--phase --claim` correctly excludes blocked tasks within the phase
+
+**Run command:** `go test -run "TestNextCommandPhaseClaimClaimsAllReadyTasksInPhase|TestNextCommandPhaseClaimExcludesBlockedTasks" -v ./cmd`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/next.go` | Added `case phaseFlag:` in `runNextWithClaim` switch |
+| `cmd/next_test.go` | Added two regression tests for phase-only claim |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes (`make test`)
+- [x] No lint regressions introduced
+
+**Manual verification:**
+- Confirmed regression tests fail before fix and pass after
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding flag combinations, enumerate all valid permutations and ensure each is handled
+- Add a matrix-style test covering all flag combinations for multi-flag commands
+
+## Related
+
+- Transit ticket: T-637


### PR DESCRIPTION
## Bug

`rune next --phase --claim AGENT` silently ignored the `--phase` flag and claimed only a single ready task instead of all ready tasks from the next phase.

## Root Cause

The `runNextWithClaim` switch statement in `cmd/next.go` had cases for:
- `--phase --stream --claim` ✅
- `--stream --claim` ✅
- Default (single task) ✅

But **no case for `--phase --claim`** (without `--stream`). When `phaseFlag=true` and `streamFlag=0`, execution fell through to the default case.

## Fix

Added a `case phaseFlag:` branch that calls `FindNextPhaseTasks` to discover all pending tasks in the next phase, then filters to ready tasks using `isTaskReady` — matching the pattern used by the existing phase+stream case.

## Testing

- Two regression tests added: one for basic multi-task phase claiming, one verifying blocked tasks are excluded
- Full test suite passes with no regressions

See `specs/bugfixes/next-phase-claim/report.md` for the full bugfix report.