### PR TITLE
Fix T-638: Invalid status filters silently treated as match-all

### DIFF
--- a/cmd/find.go
+++ b/cmd/find.go
@@ -67,6 +67,11 @@ func init() {
 }
 
 func runFind(cmd *cobra.Command, args []string) error {
+	// Validate status filter before doing any work
+	if err := validateStatusFilter(statusFilter); err != nil {
+		return err
+	}
+
 	// Resolve filename using git discovery if needed
 	filename, err := resolveFilename(args)
 	if err != nil {

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -729,8 +729,13 @@ func TestFindInvalidStatusFilterReturnsError(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
 	defer os.Chdir(oldDir)
 
 	tl := task.NewTaskList("Find Status Validation")
@@ -741,14 +746,9 @@ func TestFindInvalidStatusFilterReturnsError(t *testing.T) {
 		t.Fatalf("failed to write test file: %v", err)
 	}
 
-	// Save and restore global flag state
-	oldStatus := statusFilter
-	defer func() { statusFilter = oldStatus }()
-
-	statusFilter = "bogus"
-	cmd := findCmd
-	cmd.SetArgs([]string{testFile, "--pattern", "Setup"})
-	err = cmd.RunE(cmd, []string{testFile})
+	rootCmd.SetArgs([]string{"find", testFile, "--pattern", "Setup", "--status", "bogus"})
+	err = rootCmd.Execute()
+	rootCmd.SetArgs([]string{})
 	if err == nil {
 		t.Error("expected error for invalid --status value 'bogus', got nil")
 	}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -719,3 +719,40 @@ func TestFindFilteredJSONOutputNoStaleParentIDs(t *testing.T) {
 		}
 	}
 }
+
+// TestFindInvalidStatusFilterReturnsError verifies that runFind rejects invalid
+// --status values with a clear error instead of silently matching all (T-638).
+func TestFindInvalidStatusFilterReturnsError(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "rune-find-invalid-status-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	tl := task.NewTaskList("Find Status Validation")
+	tl.AddTask("", "Setup environment", "")
+	tl.AddTask("", "Run tests", "")
+	testFile := "find-status-validation.md"
+	if err := tl.WriteFile(testFile); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Save and restore global flag state
+	oldStatus := statusFilter
+	defer func() { statusFilter = oldStatus }()
+
+	statusFilter = "bogus"
+	cmd := findCmd
+	cmd.SetArgs([]string{testFile, "--pattern", "Setup"})
+	err = cmd.RunE(cmd, []string{testFile})
+	if err == nil {
+		t.Error("expected error for invalid --status value 'bogus', got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "invalid status filter") {
+		t.Errorf("error should mention 'invalid status filter', got: %v", err)
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -58,6 +58,11 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
+	// Validate status filter before doing any work
+	if err := validateStatusFilter(listFilter); err != nil {
+		return err
+	}
+
 	// Resolve filename using git discovery if needed
 	filename, err := resolveFilename(args)
 	if err != nil {
@@ -160,6 +165,24 @@ func flattenTasks(tasks []task.Task, statusFilter string) []map[string]any {
 	return result
 }
 
+// validStatusFilters lists all accepted values for the --filter / --status flag.
+var validStatusFilters = []string{"pending", "in-progress", "inprogress", "completed"}
+
+// validateStatusFilter returns an error if filter is non-empty and not a
+// recognised status value. Call this early to reject typos instead of silently
+// treating them as match-all.
+func validateStatusFilter(filter string) error {
+	if filter == "" {
+		return nil
+	}
+	for _, v := range validStatusFilters {
+		if filter == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid status filter %q: must be one of: pending, in-progress, completed", filter)
+}
+
 func matchesStatusFilter(status task.Status, filter string) bool {
 	switch filter {
 	case "pending":
@@ -169,7 +192,7 @@ func matchesStatusFilter(status task.Status, filter string) bool {
 	case "completed":
 		return status == task.Completed
 	default:
-		return true
+		return false
 	}
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -165,7 +165,11 @@ func flattenTasks(tasks []task.Task, statusFilter string) []map[string]any {
 	return result
 }
 
-// validStatusFilters lists all accepted values for the --filter / --status flag.
+// canonicalStatusValues are the documented status values shown in help and error messages.
+var canonicalStatusValues = []string{"pending", "in-progress", "completed"}
+
+// validStatusFilters lists all accepted values for the --filter / --status flag,
+// including convenience aliases like "inprogress".
 var validStatusFilters = []string{"pending", "in-progress", "inprogress", "completed"}
 
 // validateStatusFilter returns an error if filter is non-empty and not a
@@ -180,7 +184,7 @@ func validateStatusFilter(filter string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid status filter %q: must be one of: %s", filter, strings.Join(validStatusFilters, ", "))
+	return fmt.Errorf("invalid status filter %q: must be one of: %s", filter, strings.Join(canonicalStatusValues, ", "))
 }
 
 func matchesStatusFilter(status task.Status, filter string) bool {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -180,7 +180,7 @@ func validateStatusFilter(filter string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid status filter %q: must be one of: pending, in-progress, completed", filter)
+	return fmt.Errorf("invalid status filter %q: must be one of: %s", filter, strings.Join(validStatusFilters, ", "))
 }
 
 func matchesStatusFilter(status task.Status, filter string) bool {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1305,3 +1305,88 @@ func collectParentIDs(tasks []task.Task) map[string]string {
 	}
 	return result
 }
+
+// TestValidateStatusFilter verifies that invalid --filter values are rejected
+// with a clear error instead of being silently treated as match-all (T-638).
+func TestValidateStatusFilter(t *testing.T) {
+	tests := map[string]struct {
+		filter  string
+		wantErr bool
+	}{
+		"empty string is valid":             {filter: "", wantErr: false},
+		"pending is valid":                  {filter: "pending", wantErr: false},
+		"in-progress is valid":              {filter: "in-progress", wantErr: false},
+		"inprogress is valid":               {filter: "inprogress", wantErr: false},
+		"completed is valid":                {filter: "completed", wantErr: false},
+		"typo complete is invalid":          {filter: "complete", wantErr: true},
+		"typo pend is invalid":              {filter: "pend", wantErr: true},
+		"nonsense is invalid":               {filter: "nonsense", wantErr: true},
+		"done is invalid":                   {filter: "done", wantErr: true},
+		"PENDING uppercase is invalid":      {filter: "PENDING", wantErr: true},
+		"in_progress underscore is invalid": {filter: "in_progress", wantErr: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateStatusFilter(tc.filter)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateStatusFilter(%q) should have returned an error", tc.filter)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateStatusFilter(%q) returned unexpected error: %v", tc.filter, err)
+			}
+		})
+	}
+}
+
+// TestMatchesStatusFilterRejectsUnknown verifies that matchesStatusFilter
+// returns false for unrecognised values (T-638). Before the fix, the default
+// case returned true, silently treating invalid filters as match-all.
+func TestMatchesStatusFilterRejectsUnknown(t *testing.T) {
+	statuses := []task.Status{task.Pending, task.InProgress, task.Completed}
+	invalidFilters := []string{"complete", "nonsense", "done", "PENDING"}
+
+	for _, filter := range invalidFilters {
+		for _, status := range statuses {
+			if matchesStatusFilter(status, filter) {
+				t.Errorf("matchesStatusFilter(%v, %q) = true, want false", status, filter)
+			}
+		}
+	}
+}
+
+// TestListInvalidFilterReturnsError exercises the full runList path with an
+// invalid --filter value to ensure it produces an error (T-638).
+func TestListInvalidFilterReturnsError(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "rune-invalid-filter-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	tl := task.NewTaskList("Filter Validation Test")
+	tl.AddTask("", "Task one", "")
+	testFile := "filter-validation.md"
+	if err := tl.WriteFile(testFile); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Save and restore global flag state
+	oldFilter := listFilter
+	defer func() { listFilter = oldFilter }()
+
+	listFilter = "bogus"
+	cmd := listCmd
+	cmd.SetArgs([]string{testFile})
+	err = cmd.RunE(cmd, []string{testFile})
+	if err == nil {
+		t.Error("expected error for invalid --filter value 'bogus', got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "invalid status filter") {
+		t.Errorf("error should mention 'invalid status filter', got: %v", err)
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1355,7 +1355,7 @@ func TestMatchesStatusFilterRejectsUnknown(t *testing.T) {
 	}
 }
 
-// TestListInvalidFilterReturnsError exercises the full runList path with an
+// TestListInvalidFilterReturnsError exercises the full CLI path with an
 // invalid --filter value to ensure it produces an error (T-638).
 func TestListInvalidFilterReturnsError(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "rune-invalid-filter-test")
@@ -1364,8 +1364,13 @@ func TestListInvalidFilterReturnsError(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
 	defer os.Chdir(oldDir)
 
 	tl := task.NewTaskList("Filter Validation Test")
@@ -1375,14 +1380,9 @@ func TestListInvalidFilterReturnsError(t *testing.T) {
 		t.Fatalf("failed to write test file: %v", err)
 	}
 
-	// Save and restore global flag state
-	oldFilter := listFilter
-	defer func() { listFilter = oldFilter }()
-
-	listFilter = "bogus"
-	cmd := listCmd
-	cmd.SetArgs([]string{testFile})
-	err = cmd.RunE(cmd, []string{testFile})
+	rootCmd.SetArgs([]string{"list", testFile, "--filter", "bogus"})
+	err = rootCmd.Execute()
+	rootCmd.SetArgs([]string{})
 	if err == nil {
 		t.Error("expected error for invalid --filter value 'bogus', got nil")
 	}

--- a/specs/bugfixes/invalid-status-silent/report.md
+++ b/specs/bugfixes/invalid-status-silent/report.md
@@ -1,0 +1,82 @@
+# Bugfix Report: Invalid Status Filter Silent Match-All
+
+**Date:** 2025-07-15
+**Status:** Fixed
+**Ticket:** T-638
+
+## Description of the Issue
+
+When users passed an invalid value to the `--filter` flag on `list` or the `--status` flag on `find`, the command silently treated it as a match-all filter, returning all tasks. This was confusing because a typo like `--filter complete` (instead of `completed`) would show all tasks with no indication that the filter was ignored.
+
+**Reproduction steps:**
+1. Create a task file with pending and completed tasks
+2. Run `rune list tasks.md --filter bogus`
+3. Observe that ALL tasks are returned instead of an error
+
+**Impact:** Medium — users relying on status filtering could get incorrect results from typos without any warning.
+
+## Investigation Summary
+
+- **Symptoms examined:** Invalid status strings passed to `--filter`/`--status` produced output identical to no filter at all
+- **Code inspected:** `cmd/list.go` (matchesStatusFilter, runList), `cmd/find.go` (runFind, applyAdditionalFilters)
+- **Hypotheses tested:** Confirmed the `default` case in `matchesStatusFilter()` returned `true`
+
+## Discovered Root Cause
+
+The `matchesStatusFilter()` function in `cmd/list.go:172` used `default: return true` in its switch statement. This meant any unrecognised status string (typos, garbage) would match every task, effectively disabling the filter.
+
+**Defect type:** Missing input validation
+
+**Why it occurred:** The function was designed to handle the "no filter" case (empty string) and valid values, but the default arm was written as a catch-all pass-through rather than a rejection.
+
+**Contributing factors:** No flag-level validation in Cobra, and no early validation in the command runners.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/list.go` — Added `validateStatusFilter()` function that rejects unrecognised values with a clear error listing valid options. Called at the start of `runList()`. Changed `matchesStatusFilter()` default from `return true` to `return false`.
+- `cmd/find.go` — Added `validateStatusFilter()` call at the start of `runFind()`.
+
+**Approach rationale:** Early validation with a clear error message is the most user-friendly approach. Changing the default in `matchesStatusFilter` to `false` provides defence-in-depth.
+
+**Alternatives considered:**
+- Cobra `ValidArgsFunction` — only helps shell completion, doesn't prevent invalid values
+- Case-insensitive matching — would mask the issue but could introduce ambiguity
+
+## Regression Test
+
+**Test file:** `cmd/list_test.go`, `cmd/find_test.go`
+**Test names:** `TestValidateStatusFilter`, `TestMatchesStatusFilterRejectsUnknown`, `TestListInvalidFilterReturnsError`, `TestFindInvalidStatusFilterReturnsError`
+
+**What it verifies:** Invalid status values are rejected with errors; valid values (including empty) are accepted; the full command path returns an error for invalid filters.
+
+**Run command:** `go test -run 'TestValidateStatusFilter|TestMatchesStatusFilterRejectsUnknown|TestListInvalidFilterReturnsError|TestFindInvalidStatusFilterReturnsError' -v ./cmd`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/list.go` | Added `validateStatusFilter()`, changed `matchesStatusFilter` default to `false`, added validation call in `runList` |
+| `cmd/find.go` | Added validation call in `runFind` |
+| `cmd/list_test.go` | Added 3 regression tests |
+| `cmd/find_test.go` | Added 1 regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Code formatted with `make fmt`
+
+**Manual verification:**
+- `rune list file.md --filter bogus` → error with valid options listed
+- `rune find file.md -p "x" --status bogus` → error with valid options listed
+- `rune list file.md --filter pending` → works correctly
+- `rune find file.md -p "x" --status completed` → works correctly
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Validate CLI flag values early in command runners before doing any work
+- Use `default: return false` in filter-matching switch statements (fail-closed)
+- Consider adding a shared `RegisterStatusFlagValidation` helper for future flags with constrained values


### PR DESCRIPTION
## Bug

Invalid `--filter` values on `list` and invalid `--status` values on `find` were silently treated as match-all, returning all tasks instead of an error. A typo like `--filter complete` (instead of `completed`) would produce misleading output.

## Root Cause

`matchesStatusFilter()` in `cmd/list.go` had `default: return true` in its switch statement, causing any unrecognised status string to match every task.

## Fix

- Added `validateStatusFilter()` that rejects invalid values with a clear error listing valid options (`pending`, `in-progress`, `completed`)
- Called early in both `runList()` and `runFind()` before any file processing
- Changed `matchesStatusFilter()` default from `return true` to `return false` (defence-in-depth)
- Added 4 regression tests covering validation, filter matching, and full command error paths

## Testing

All existing tests pass. See `specs/bugfixes/invalid-status-silent/report.md` for full report.