### PR TITLE
Fix T-685: ValidateFilePath Allows Symlink Escape Outside Working Directory

### DIFF
--- a/cmd/integration_renumber_test.go
+++ b/cmd/integration_renumber_test.go
@@ -529,13 +529,9 @@ func testRenumberSymlinkSecurity(t *testing.T, tempDir string) {
 	cmd := exec.Command(runeBinaryPath, "renumber", symlinkPath)
 	output, err := cmd.CombinedOutput()
 
-	// NOTE: There is a known issue where ValidateFilePath does not properly
-	// reject symlinks pointing outside the working directory. This affects
-	// all commands, not just renumber. This should be fixed in ValidateFilePath.
-	// For now, we log a warning instead of failing the test.
+	// ValidateFilePath now resolves symlinks and should reject this
 	if err == nil {
-		t.Logf("WARNING: renumber should have failed for symlink pointing outside working directory (known ValidateFilePath issue)")
-		t.Logf("Renumber output: %s", output)
+		t.Errorf("renumber should have failed for symlink pointing outside working directory, output: %s", output)
 	} else {
 		t.Logf("Renumber correctly rejected symlink: %s", output)
 

--- a/internal/task/fileops_test.go
+++ b/internal/task/fileops_test.go
@@ -206,6 +206,90 @@ func TestPathTraversalProtection(t *testing.T) {
 	}
 }
 
+// Test that ValidateFilePath rejects symlinks pointing outside working directory
+func TestValidateFilePath_SymlinkEscape(t *testing.T) {
+	// Create a temporary working directory
+	workDir, err := os.MkdirTemp("", "rune-symlink-test-work-")
+	if err != nil {
+		t.Fatalf("Failed to create work dir: %v", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	// Create an outside directory with a target file
+	outsideDir, err := os.MkdirTemp("", "rune-symlink-test-outside-")
+	if err != nil {
+		t.Fatalf("Failed to create outside dir: %v", err)
+	}
+	defer os.RemoveAll(outsideDir)
+
+	outsideFile := filepath.Join(outsideDir, "secret.md")
+	if err := os.WriteFile(outsideFile, []byte("secret data"), 0644); err != nil {
+		t.Fatalf("Failed to create outside file: %v", err)
+	}
+
+	// Create a symlink inside workDir that points to the outside file
+	symlinkPath := filepath.Join(workDir, "escape.md")
+	if err := os.Symlink(outsideFile, symlinkPath); err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	// Create a symlink to the outside directory itself
+	symlinkDir := filepath.Join(workDir, "escape-dir")
+	if err := os.Symlink(outsideDir, symlinkDir); err != nil {
+		t.Fatalf("Failed to create dir symlink: %v", err)
+	}
+
+	// Switch to the working directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current dir: %v", err)
+	}
+	defer os.Chdir(originalDir)
+
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "symlink to file outside working directory",
+			path:    "escape.md",
+			wantErr: true,
+		},
+		{
+			name:    "file via symlinked directory outside working directory",
+			path:    "escape-dir/secret.md",
+			wantErr: true,
+		},
+		{
+			name:    "non-symlink file is still allowed",
+			path:    "normal.md",
+			wantErr: false,
+		},
+	}
+
+	// Create a normal (non-symlink) file for the positive test case
+	if err := os.WriteFile(filepath.Join(workDir, "normal.md"), []byte("ok"), 0644); err != nil {
+		t.Fatalf("Failed to create normal file: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFilePath(tt.path)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for symlink path %q, got nil", tt.path)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for path %q: %v", tt.path, err)
+			}
+		})
+	}
+}
+
 // Test atomic write operations
 func TestAtomicWriteOperations(t *testing.T) {
 	// Create temporary directory

--- a/internal/task/fileops_test.go
+++ b/internal/task/fileops_test.go
@@ -206,21 +206,23 @@ func TestPathTraversalProtection(t *testing.T) {
 	}
 }
 
-// Test that ValidateFilePath rejects symlinks pointing outside working directory
+// Test that ValidateFilePath rejects symlinks pointing outside working directory.
+// NOTE: os.Chdir modifies global process state — do not add t.Parallel() to this
+// test or any test in this package that depends on the working directory.
 func TestValidateFilePath_SymlinkEscape(t *testing.T) {
 	// Create a temporary working directory
 	workDir, err := os.MkdirTemp("", "rune-symlink-test-work-")
 	if err != nil {
 		t.Fatalf("Failed to create work dir: %v", err)
 	}
-	defer os.RemoveAll(workDir)
+	t.Cleanup(func() { os.RemoveAll(workDir) })
 
 	// Create an outside directory with a target file
 	outsideDir, err := os.MkdirTemp("", "rune-symlink-test-outside-")
 	if err != nil {
 		t.Fatalf("Failed to create outside dir: %v", err)
 	}
-	defer os.RemoveAll(outsideDir)
+	t.Cleanup(func() { os.RemoveAll(outsideDir) })
 
 	outsideFile := filepath.Join(outsideDir, "secret.md")
 	if err := os.WriteFile(outsideFile, []byte("secret data"), 0644); err != nil {
@@ -239,52 +241,48 @@ func TestValidateFilePath_SymlinkEscape(t *testing.T) {
 		t.Fatalf("Failed to create dir symlink: %v", err)
 	}
 
-	// Switch to the working directory
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current dir: %v", err)
-	}
-	defer os.Chdir(originalDir)
-
-	if err := os.Chdir(workDir); err != nil {
-		t.Fatalf("Failed to chdir: %v", err)
-	}
-
-	tests := []struct {
-		name    string
-		path    string
-		wantErr bool
-	}{
-		{
-			name:    "symlink to file outside working directory",
-			path:    "escape.md",
-			wantErr: true,
-		},
-		{
-			name:    "file via symlinked directory outside working directory",
-			path:    "escape-dir/secret.md",
-			wantErr: true,
-		},
-		{
-			name:    "non-symlink file is still allowed",
-			path:    "normal.md",
-			wantErr: false,
-		},
-	}
-
 	// Create a normal (non-symlink) file for the positive test case
 	if err := os.WriteFile(filepath.Join(workDir, "normal.md"), []byte("ok"), 0644); err != nil {
 		t.Fatalf("Failed to create normal file: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateFilePath(tt.path)
-			if tt.wantErr && err == nil {
-				t.Errorf("expected error for symlink path %q, got nil", tt.path)
+	// Switch to the working directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+
+	tests := map[string]struct {
+		path    string
+		wantErr bool
+	}{
+		"symlink to file outside working directory": {
+			path:    "escape.md",
+			wantErr: true,
+		},
+		"file via symlinked directory outside working directory": {
+			path:    "escape-dir/secret.md",
+			wantErr: true,
+		},
+		"non-symlink file is still allowed": {
+			path:    "normal.md",
+			wantErr: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateFilePath(tc.path)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for symlink path %q, got nil", tc.path)
 			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error for path %q: %v", tt.path, err)
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for path %q: %v", tc.path, err)
 			}
 		})
 	}

--- a/internal/task/operations.go
+++ b/internal/task/operations.go
@@ -375,13 +375,59 @@ func ValidateFilePath(path string) error {
 		return fmt.Errorf("resolving file path: %w", err)
 	}
 
-	// Ensure resolved path is within working directory tree
-	// This prevents both absolute and relative path traversal attacks
+	// Lexical containment check first (fast path)
 	if !strings.HasPrefix(absPath, workDirAbs+string(filepath.Separator)) && absPath != workDirAbs {
 		return fmt.Errorf("path traversal attempt detected")
 	}
 
+	// Resolve symlinks to prevent escaping the working directory via symlinks.
+	// EvalSymlinks requires the path (or its parent) to exist, so we walk up
+	// until we find an existing ancestor and resolve from there.
+	realWorkDir, err := filepath.EvalSymlinks(workDirAbs)
+	if err != nil {
+		return fmt.Errorf("resolving working directory symlinks: %w", err)
+	}
+
+	realPath, err := resolveExistingPrefix(absPath)
+	if err != nil {
+		return fmt.Errorf("resolving file path symlinks: %w", err)
+	}
+
+	// Re-check containment after symlink resolution
+	if !strings.HasPrefix(realPath, realWorkDir+string(filepath.Separator)) && realPath != realWorkDir {
+		return fmt.Errorf("path traversal attempt detected: symlink resolves outside working directory")
+	}
+
 	return nil
+}
+
+// resolveExistingPrefix resolves symlinks for the longest existing prefix of
+// path, then appends the remaining unresolved tail. This handles the case
+// where the file itself does not yet exist (e.g. create operations) but an
+// ancestor directory contains a symlink.
+func resolveExistingPrefix(path string) (string, error) {
+	// Try resolving the full path first (common case: file exists)
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved, nil
+	}
+
+	// Walk up to find the deepest existing ancestor
+	dir := filepath.Dir(path)
+	tail := filepath.Base(path)
+
+	for dir != path {
+		resolved, err = filepath.EvalSymlinks(dir)
+		if err == nil {
+			return filepath.Join(resolved, tail), nil
+		}
+		tail = filepath.Join(filepath.Base(dir), tail)
+		path = dir
+		dir = filepath.Dir(dir)
+	}
+
+	// Nothing resolved; return the original absolute path
+	return filepath.Abs(path)
 }
 
 // validateTaskInput sanitizes and validates task input

--- a/internal/task/operations.go
+++ b/internal/task/operations.go
@@ -405,29 +405,30 @@ func ValidateFilePath(path string) error {
 // path, then appends the remaining unresolved tail. This handles the case
 // where the file itself does not yet exist (e.g. create operations) but an
 // ancestor directory contains a symlink.
-func resolveExistingPrefix(path string) (string, error) {
+func resolveExistingPrefix(absPath string) (string, error) {
 	// Try resolving the full path first (common case: file exists)
-	resolved, err := filepath.EvalSymlinks(path)
+	resolved, err := filepath.EvalSymlinks(absPath)
 	if err == nil {
 		return resolved, nil
 	}
 
 	// Walk up to find the deepest existing ancestor
-	dir := filepath.Dir(path)
-	tail := filepath.Base(path)
+	dir := filepath.Dir(absPath)
+	tail := filepath.Base(absPath)
+	cursor := absPath
 
-	for dir != path {
+	for dir != cursor {
 		resolved, err = filepath.EvalSymlinks(dir)
 		if err == nil {
 			return filepath.Join(resolved, tail), nil
 		}
 		tail = filepath.Join(filepath.Base(dir), tail)
-		path = dir
+		cursor = dir
 		dir = filepath.Dir(dir)
 	}
 
-	// Nothing resolved; return the original absolute path
-	return filepath.Abs(path)
+	// Filesystem root could not be resolved; return as-is (safe: will fail containment check)
+	return cursor, nil
 }
 
 // validateTaskInput sanitizes and validates task input

--- a/specs/bugfixes/validate-filepath-symlink-escape/report.md
+++ b/specs/bugfixes/validate-filepath-symlink-escape/report.md
@@ -1,0 +1,75 @@
+# Bugfix Report: ValidateFilePath Symlink Escape
+
+**Date:** 2026-04-16
+**Status:** Fixed
+
+## Description of the Issue
+
+`ValidateFilePath` only performed lexical path resolution (`filepath.Abs` + `filepath.Clean`) and checked containment via `strings.HasPrefix`. A symlink inside the working directory pointing to a file outside it would pass validation, allowing commands like `renumber` to modify files outside the project root.
+
+**Reproduction steps:**
+1. Create a file outside the working directory
+2. Create a symlink inside the working directory pointing to that file
+3. Run any rune command (e.g., `rune renumber symlink.md`) targeting the symlink
+4. Observe: the command succeeds and modifies the external file
+
+**Impact:** Security — any command using `ValidateFilePath` (all write commands) could be tricked into modifying arbitrary files via symlinks.
+
+## Investigation Summary
+
+- **Symptoms examined:** `ValidateFilePath` uses only lexical path checks
+- **Code inspected:** `internal/task/operations.go:ValidateFilePath`, `cmd/integration_renumber_test.go` (known-issue comments at lines 532-537)
+- **Hypotheses tested:** Confirmed that `filepath.Abs(filepath.Clean(path))` does not resolve symlinks
+
+## Discovered Root Cause
+
+`ValidateFilePath` resolved paths lexically but never called `filepath.EvalSymlinks`. A symlink like `workdir/escape.md -> /outside/secret.md` has a lexical absolute path inside the working directory, so the `HasPrefix` check passes.
+
+**Defect type:** Missing validation (symlink resolution)
+
+**Why it occurred:** The original implementation only considered lexical path traversal attacks (`../`), not filesystem-level indirection via symlinks.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/operations.go:ValidateFilePath` — After the lexical containment check, resolve symlinks on both the working directory and the target path using `filepath.EvalSymlinks`, then re-check containment.
+- `internal/task/operations.go:resolveExistingPrefix` — New helper that resolves symlinks for the longest existing ancestor path, handling the case where the target file doesn't exist yet.
+
+**Approach rationale:** Two-phase validation (lexical then physical) preserves the fast-path rejection of obvious traversal attempts while catching symlink escapes.
+
+**Alternatives considered:**
+- Rejecting all symlinks outright — too restrictive; symlinks within the working directory to other locations within it are legitimate.
+- Using `os.Lstat` to detect symlinks before opening — doesn't catch symlinked parent directories.
+
+## Regression Test
+
+**Test file:** `internal/task/fileops_test.go`
+**Test name:** `TestValidateFilePath_SymlinkEscape`
+
+**What it verifies:** Symlinks to files and directories outside the working directory are rejected; normal files still pass.
+
+**Run command:** `go test -run TestValidateFilePath_SymlinkEscape -v ./internal/task/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/operations.go` | Added symlink resolution to `ValidateFilePath`; added `resolveExistingPrefix` helper |
+| `internal/task/fileops_test.go` | Added `TestValidateFilePath_SymlinkEscape` regression test |
+| `cmd/integration_renumber_test.go` | Changed known-issue warning to a proper assertion |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`go test ./...`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Any path-based security check must resolve symlinks before containment validation
+- Consider using `os.OpenFile` with `O_NOFOLLOW` where symlink following is explicitly undesired
+
+## Related
+
+- Transit ticket T-685


### PR DESCRIPTION
## Summary

`ValidateFilePath` only performed lexical path resolution (`filepath.Abs` + `filepath.Clean`) without resolving symlinks. A symlink inside the working directory pointing to a file outside it bypassed the traversal protection, allowing write commands to modify arbitrary files.

## Root Cause

The containment check used `strings.HasPrefix` on the lexically-resolved absolute path. Since symlinks don't change the lexical path, a symlink like `workdir/escape.md -> /outside/secret.md` would pass validation.

## Fix

Added a second containment check after resolving symlinks with `filepath.EvalSymlinks` on both the working directory and the target path. A `resolveExistingPrefix` helper handles the case where the target file doesn't yet exist by resolving the longest existing ancestor.

## Changes

- `internal/task/operations.go` — Symlink resolution in `ValidateFilePath`; new `resolveExistingPrefix` helper
- `internal/task/fileops_test.go` — Regression test `TestValidateFilePath_SymlinkEscape`
- `cmd/integration_renumber_test.go` — Changed known-issue warning to proper assertion
- `specs/bugfixes/validate-filepath-symlink-escape/report.md` — Bugfix report

## Testing

All tests pass: `go test ./...`

Closes T-685