### PR TITLE
Fix T-674: Parser Silently Ignores Invalid Indented Non-Task Lines

### DIFF
--- a/internal/task/parse.go
+++ b/internal/task/parse.go
@@ -247,9 +247,7 @@ func parseTasksAtLevel(lines []string, startIdx, expectedIndent int, parentID st
 			// This is a detail line at the wrong level
 			return nil, i, fmt.Errorf("line %d: unexpected content at this indentation level", i+1)
 		default:
-			// Skip lines that don't match task pattern but have deeper indentation
-			// These will be caught as unexpected indentation if they're in the wrong place
-			continue
+			return nil, i, fmt.Errorf("line %d: unexpected content at this indentation level", i+1)
 		}
 	}
 

--- a/internal/task/parse_invalid_indent_test.go
+++ b/internal/task/parse_invalid_indent_test.go
@@ -13,27 +13,36 @@ import (
 // The parser must return an error for such lines instead.
 
 func TestParseRejectsIndentedNonTaskLines(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		content     string
 		errContains string
 	}{
+		// Exercises the new default branch in parseTasksAtLevel:
+		// 2-space indent (expectedIndent+2) non-task line at root level.
 		"indented_plain_text_before_task": {
 			content: `# Tasks
   not-a-task line
 - [ ] 1. Real task`,
-			errContains: "unexpected",
+			errContains: "unexpected content",
 		},
 		"indented_plain_text_only": {
 			content: `# Tasks
   just some indented text`,
-			errContains: "unexpected",
+			errContains: "unexpected content",
 		},
+		// Pre-existing validation: 4-space indent at root is caught by the
+		// indent > expectedIndent && indent != expectedIndent+2 guard, not
+		// by the default branch fixed in this change.
 		"double_indented_plain_text_at_root": {
 			content: `# Tasks
     deeply indented line
 - [ ] 1. Real task`,
 			errContains: "unexpected indentation",
 		},
+		// Exercises parseDetailsAndChildren (different code path), not the
+		// default branch in parseTasksAtLevel. Kept as a regression guard.
 		"indented_non_task_at_child_level": {
 			content: `# Tasks
 - [ ] 1. Parent task
@@ -45,6 +54,8 @@ func TestParseRejectsIndentedNonTaskLines(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := ParseMarkdown([]byte(tc.content))
 			if err == nil {
 				t.Fatal("expected error but got nil")
@@ -57,16 +68,20 @@ func TestParseRejectsIndentedNonTaskLines(t *testing.T) {
 }
 
 func TestParseAllowsValidIndentedContent(t *testing.T) {
+	t.Parallel()
+
 	// Ensure we don't break valid indented content (detail lines, subtasks).
 	tests := map[string]struct {
-		content   string
-		wantTasks int
+		content      string
+		wantTasks    int
+		wantChildren int // expected children of first task (0 = don't check)
 	}{
 		"subtasks_are_valid": {
 			content: `# Tasks
 - [ ] 1. Parent
   - [ ] 1.1. Child`,
-			wantTasks: 1,
+			wantTasks:    1,
+			wantChildren: 1,
 		},
 		"detail_lines_are_valid": {
 			content: `# Tasks
@@ -85,12 +100,19 @@ func TestParseAllowsValidIndentedContent(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			tl, err := ParseMarkdown([]byte(tc.content))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if len(tl.Tasks) != tc.wantTasks {
 				t.Errorf("got %d tasks, want %d", len(tl.Tasks), tc.wantTasks)
+			}
+			if tc.wantChildren > 0 && len(tl.Tasks) > 0 {
+				if got := len(tl.Tasks[0].Children); got != tc.wantChildren {
+					t.Errorf("got %d children, want %d", got, tc.wantChildren)
+				}
 			}
 		})
 	}

--- a/internal/task/parse_invalid_indent_test.go
+++ b/internal/task/parse_invalid_indent_test.go
@@ -1,0 +1,97 @@
+package task
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for T-674: Parser silently ignores invalid indented
+// non-task lines at task level.
+//
+// parseTasksAtLevel used to silently skip non-task lines whose indentation
+// was deeper than the current level (the default branch did `continue`).
+// The parser must return an error for such lines instead.
+
+func TestParseRejectsIndentedNonTaskLines(t *testing.T) {
+	tests := map[string]struct {
+		content     string
+		errContains string
+	}{
+		"indented_plain_text_before_task": {
+			content: `# Tasks
+  not-a-task line
+- [ ] 1. Real task`,
+			errContains: "unexpected",
+		},
+		"indented_plain_text_only": {
+			content: `# Tasks
+  just some indented text`,
+			errContains: "unexpected",
+		},
+		"double_indented_plain_text_at_root": {
+			content: `# Tasks
+    deeply indented line
+- [ ] 1. Real task`,
+			errContains: "unexpected indentation",
+		},
+		"indented_non_task_at_child_level": {
+			content: `# Tasks
+- [ ] 1. Parent task
+    not-a-task at grandchild level
+  - [ ] 1.1. Child task`,
+			errContains: "unexpected",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseMarkdown([]byte(tc.content))
+			if err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+func TestParseAllowsValidIndentedContent(t *testing.T) {
+	// Ensure we don't break valid indented content (detail lines, subtasks).
+	tests := map[string]struct {
+		content   string
+		wantTasks int
+	}{
+		"subtasks_are_valid": {
+			content: `# Tasks
+- [ ] 1. Parent
+  - [ ] 1.1. Child`,
+			wantTasks: 1,
+		},
+		"detail_lines_are_valid": {
+			content: `# Tasks
+- [ ] 1. Parent
+  - Some detail`,
+			wantTasks: 1,
+		},
+		"phase_headers_at_root_are_valid": {
+			content: `# Tasks
+- [ ] 1. First task
+## Phase 2
+- [ ] 2. Second task`,
+			wantTasks: 2,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tl, err := ParseMarkdown([]byte(tc.content))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(tl.Tasks) != tc.wantTasks {
+				t.Errorf("got %d tasks, want %d", len(tl.Tasks), tc.wantTasks)
+			}
+		})
+	}
+}

--- a/specs/bugfixes/parser-ignores-invalid-indented-lines/report.md
+++ b/specs/bugfixes/parser-ignores-invalid-indented-lines/report.md
@@ -1,0 +1,76 @@
+# Bugfix Report: parser-ignores-invalid-indented-lines
+
+**Date:** 2026-04-16
+**Status:** Fixed
+**Transit:** T-674
+
+## Description of the Issue
+
+The parser's `parseTasksAtLevel` function silently ignored non-task lines that had indentation deeper than the current parsing level. Instead of returning a parse error, these lines were skipped via a `continue` in the `default` switch branch, causing malformed content to be silently dropped.
+
+**Reproduction steps:**
+1. Create a markdown file with indented non-task text before or instead of tasks:
+   ```markdown
+   # Tasks
+     not-a-task line
+   - [ ] 1. Real task
+   ```
+2. Parse the file with `rune list`
+3. Observe: parse succeeds, the indented non-task line is silently ignored
+
+**Impact:** Malformed task files would parse without error, silently dropping content. Users wouldn't know their file had formatting issues.
+
+## Investigation Summary
+
+- **Symptoms examined:** Non-task lines with deeper indentation were silently skipped
+- **Code inspected:** `internal/task/parse.go`, specifically `parseTasksAtLevel`
+- **Hypotheses tested:** The `default` branch of the switch in `parseTasksAtLevel` (line ~249) used `continue` instead of returning an error
+
+## Discovered Root Cause
+
+In `parseTasksAtLevel`, after checking if a line is a task and checking for same-level non-task content, the `default` switch branch caught all remaining cases — non-task lines at deeper indentation (exactly `expectedIndent+2`). This branch simply called `continue`, silently skipping the line.
+
+**Defect type:** Missing validation
+
+**Why it occurred:** The default branch was written as a catch-all with the assumption that invalid indentation would be caught elsewhere, but lines at exactly `expectedIndent+2` that weren't tasks slipped through.
+
+**Contributing factors:** The indentation validation above the switch correctly rejected indentation that wasn't a multiple of 2, but lines at the next valid indent level that weren't tasks were not caught.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/parse.go:250` — Changed `default` branch from `continue` to return an error: `"unexpected content at this indentation level"`
+
+**Approach rationale:** The simplest correct fix — any non-task content at a deeper indentation level than expected in `parseTasksAtLevel` is invalid and should produce a parse error, consistent with how the `indent == expectedIndent` case already handles unexpected content.
+
+**Alternatives considered:**
+- Treating the content as a detail line — rejected because detail lines belong under tasks, not at the root parsing level
+
+## Regression Test
+
+**Test file:** `internal/task/parse_invalid_indent_test.go`
+**Test name:** `TestParseRejectsIndentedNonTaskLines`
+
+**What it verifies:** The parser returns an error for non-task lines with indentation deeper than the current parsing level, including plain text before tasks, standalone indented text, deeply indented text, and indented non-task content at child levels.
+
+**Run command:** `go test -run TestParseRejectsIndentedNonTaskLines -v ./internal/task/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/parse.go` | Changed `default` branch from `continue` to error return |
+| `internal/task/parse_invalid_indent_test.go` | New regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`make test`)
+- [x] Build succeeds
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Avoid bare `continue` in parser switch defaults — always explicitly handle or error on unexpected input
+- Parser switch statements should have exhaustive case handling with explicit error returns for invalid states


### PR DESCRIPTION
## Bug

The parser's `parseTasksAtLevel` function silently ignored non-task lines with indentation deeper than the current level. The `default` switch branch used `continue` instead of returning an error, allowing malformed content to parse successfully while silently dropping content.

**Repro:**
```markdown
# Tasks
  not-a-task line
- [ ] 1. Real task
```
Parsed without error; the indented line was silently dropped.

## Root Cause

The `default` branch in the switch statement within `parseTasksAtLevel` (`internal/task/parse.go`) called `continue`, skipping non-task lines at `expectedIndent+2` without reporting an error.

## Fix

Changed the `default` branch to return an error (`unexpected content at this indentation level`) instead of silently continuing.

## Testing

- Added regression tests in `internal/task/parse_invalid_indent_test.go`
- Full test suite passes (`make test`)
- Bugfix report: `specs/bugfixes/parser-ignores-invalid-indented-lines/report.md`