### PR TITLE
Fix T-703: Streams Available JSON Stale IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Streams Command**: `streams --available --json` (and `streams --json`) now recomputes the `available` array from the filtered `streams` list, preventing stale stream IDs from appearing in `available` after `filterEmptyStreams` or `filterAvailableStreams` removes streams
 - **Next Command**: `next --phase --claim AGENT` now correctly claims all ready tasks from the next phase instead of silently ignoring `--phase` and claiming only a single task
 - **Phase Parsing**: `ParseFileWithPhases` front-matter stripping no longer treats horizontal rules (`---`) after front matter as additional front-matter delimiters, which would cause phase markers after the rule to be silently dropped
 - **Phase Parsing**: Normalize CRLF line endings in all phase-related functions (`ParseFileWithPhases`, `ExtractPhaseMarkers`, `getTaskPhase`, `getNextPhaseTasks`, `FindNextPhaseTasks`, `FindNextPhaseTasksForStream`, and phase-aware operations) by introducing a `splitLines` helper that trims `\r` after splitting on `\n`

--- a/cmd/streams.go
+++ b/cmd/streams.go
@@ -84,32 +84,38 @@ func runStreams(cmd *cobra.Command, args []string) error {
 	return outputStreamsTable(result)
 }
 
-// filterAvailableStreams returns only streams that have ready tasks
+// filterAvailableStreams returns only streams that have ready tasks.
+// Available is recomputed from the surviving streams.
 func filterAvailableStreams(result *task.StreamsResult) *task.StreamsResult {
 	filtered := &task.StreamsResult{
 		Streams:   make([]task.StreamStatus, 0),
-		Available: result.Available,
+		Available: []int{},
 	}
 
 	for _, stream := range result.Streams {
 		if len(stream.Ready) > 0 {
 			filtered.Streams = append(filtered.Streams, stream)
+			filtered.Available = append(filtered.Available, stream.ID)
 		}
 	}
 
 	return filtered
 }
 
-// filterEmptyStreams removes streams that have no pending tasks (all completed)
+// filterEmptyStreams removes streams that have no pending tasks (all completed).
+// Available is recomputed from the surviving streams.
 func filterEmptyStreams(result *task.StreamsResult) *task.StreamsResult {
 	filtered := &task.StreamsResult{
 		Streams:   make([]task.StreamStatus, 0),
-		Available: result.Available,
+		Available: []int{},
 	}
 
 	for _, stream := range result.Streams {
 		if len(stream.Ready) > 0 || len(stream.Blocked) > 0 || len(stream.Active) > 0 {
 			filtered.Streams = append(filtered.Streams, stream)
+			if len(stream.Ready) > 0 {
+				filtered.Available = append(filtered.Available, stream.ID)
+			}
 		}
 	}
 

--- a/cmd/streams_test.go
+++ b/cmd/streams_test.go
@@ -389,6 +389,63 @@ func TestStreamsCommandWithAvailableFilter(t *testing.T) {
 	}
 }
 
+// TestFilterEmptyStreamsRecomputesAvailable verifies that filterEmptyStreams
+// recomputes Available from the surviving streams rather than copying stale IDs.
+// Regression test for T-703.
+func TestFilterEmptyStreamsRecomputesAvailable(t *testing.T) {
+	// Craft a StreamsResult where Available is stale: it claims stream 2
+	// is available, but stream 2 has no ready/blocked/active tasks and
+	// should be dropped by filterEmptyStreams.
+	input := &task.StreamsResult{
+		Streams: []task.StreamStatus{
+			{ID: 1, Ready: []string{"1"}, Blocked: []string{}, Active: []string{}},
+			{ID: 2, Ready: []string{}, Blocked: []string{}, Active: []string{}},
+		},
+		Available: []int{1, 2}, // stale: stream 2 has no ready tasks
+	}
+
+	result := filterEmptyStreams(input)
+
+	if len(result.Streams) != 1 {
+		t.Fatalf("expected 1 stream after filtering, got %d", len(result.Streams))
+	}
+	if result.Streams[0].ID != 1 {
+		t.Errorf("expected stream 1, got stream %d", result.Streams[0].ID)
+	}
+	// Available must be recomputed: only stream 1 survives and has ready tasks.
+	if len(result.Available) != 1 || result.Available[0] != 1 {
+		t.Errorf("expected available=[1], got %v", result.Available)
+	}
+}
+
+// TestFilterAvailableStreamsRecomputesAvailable verifies that filterAvailableStreams
+// recomputes Available from the surviving streams rather than copying stale IDs.
+// Regression test for T-703.
+func TestFilterAvailableStreamsRecomputesAvailable(t *testing.T) {
+	// Craft a StreamsResult where Available is stale: it claims streams 1
+	// and 2 are available, but stream 2 has only blocked tasks. After
+	// filterAvailableStreams, only stream 1 should remain.
+	input := &task.StreamsResult{
+		Streams: []task.StreamStatus{
+			{ID: 1, Ready: []string{"1"}, Blocked: []string{}, Active: []string{}},
+			{ID: 2, Ready: []string{}, Blocked: []string{"2"}, Active: []string{}},
+		},
+		Available: []int{1, 2}, // stale: stream 2 has no ready tasks
+	}
+
+	result := filterAvailableStreams(input)
+
+	if len(result.Streams) != 1 {
+		t.Fatalf("expected 1 stream after filtering, got %d", len(result.Streams))
+	}
+	if result.Streams[0].ID != 1 {
+		t.Errorf("expected stream 1, got stream %d", result.Streams[0].ID)
+	}
+	if len(result.Available) != 1 || result.Available[0] != 1 {
+		t.Errorf("expected available=[1], got %v", result.Available)
+	}
+}
+
 func TestStreamsCommandEmptyResult(t *testing.T) {
 	// Create temporary directory for test files
 	tempDir, err := os.MkdirTemp("", "rune-streams-empty-test")

--- a/specs/bugfixes/streams-available-json-stale-ids/report.md
+++ b/specs/bugfixes/streams-available-json-stale-ids/report.md
@@ -1,0 +1,74 @@
+# Bugfix Report: streams-available-json-stale-ids
+
+**Date:** 2026-04-16
+**Status:** Fixed
+**Ticket:** T-703
+
+## Description of the Issue
+
+`rune streams <file> --available --json` could return an `available` array containing stream IDs that no longer appeared in the `streams` array after filtering. The `filterEmptyStreams` and `filterAvailableStreams` functions in `cmd/streams.go` copied the original `Available` slice verbatim instead of recomputing it from the filtered stream set.
+
+**Reproduction steps:**
+1. Construct a `StreamsResult` where `Available` includes a stream ID whose stream has no ready/blocked/active tasks.
+2. Call `filterEmptyStreams` or `filterAvailableStreams`.
+3. Observe `available` still contains the removed stream's ID.
+
+**Impact:** Low-to-medium — downstream consumers parsing the JSON could attempt to use a stream ID from `available` that doesn't exist in `streams`, leading to incorrect agent scheduling or confusing output.
+
+## Investigation Summary
+
+- **Symptoms examined:** Both filter functions blindly copy `Available: result.Available`.
+- **Code inspected:** `cmd/streams.go` lines 88–117 (`filterAvailableStreams`, `filterEmptyStreams`).
+- **Hypotheses tested:** With the current `AnalyzeStreams` implementation, the stale IDs are unlikely to manifest end-to-end because `AnalyzeStreams` already computes `Available` consistently. However, the filter functions are independently wrong and would produce stale data given any upstream change.
+
+## Discovered Root Cause
+
+**Defect type:** Logic error — missing recomputation.
+
+**Why it occurred:** Both filter functions were written to construct a new `StreamsResult` but simply assigned `Available: result.Available` instead of rebuilding `Available` from the streams that survived filtering.
+
+**Contributing factors:** `Available` happens to be consistent after `AnalyzeStreams`, masking the filter-level bug in end-to-end tests.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/streams.go:88–101` — `filterAvailableStreams` now initialises `Available: []int{}` and appends each surviving stream's ID inline.
+- `cmd/streams.go:104–119` — `filterEmptyStreams` now initialises `Available: []int{}` and appends each surviving stream's ID when it has ready tasks.
+
+**Approach rationale:** Recomputing `Available` during the same loop that filters `Streams` is zero-cost and keeps the two fields permanently consistent by construction.
+
+**Alternatives considered:**
+- Adding a separate `recomputeAvailable` helper called after each filter — rejected because inlining is simpler and avoids a second pass.
+
+## Regression Test
+
+**Test file:** `cmd/streams_test.go`
+**Test names:** `TestFilterEmptyStreamsRecomputesAvailable`, `TestFilterAvailableStreamsRecomputesAvailable`
+
+**What they verify:** When given a `StreamsResult` with a deliberately stale `Available` array, the filter functions produce an `Available` array that only contains IDs present in the filtered `Streams`.
+
+**Run command:** `go test -run "TestFilter(Empty|Available)StreamsRecomputes" -v ./cmd`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/streams.go` | Recompute `Available` in both filter functions |
+| `cmd/streams_test.go` | Add two regression tests for stale Available IDs |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] Code formatted with `make fmt`
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When filtering a struct that contains derived/summary fields, always recompute those fields from the filtered data rather than copying from the original.
+- Consider making `Available` a computed method on `StreamsResult` rather than a stored field, to eliminate the possibility of staleness.
+
+## Related
+
+- Transit ticket T-703


### PR DESCRIPTION
## Bug

`streams --available --json` could return an `available` array with stream IDs not present in the filtered `streams` list.

## Root Cause

`filterEmptyStreams` and `filterAvailableStreams` in `cmd/streams.go` copied `Available: result.Available` verbatim instead of recomputing from the filtered stream set.

## Fix

Both functions now initialise `Available` as an empty slice and rebuild it inline during the filtering loop, keeping `streams` and `available` consistent by construction.

## Tests

Two regression tests verify that deliberately stale `Available` arrays are properly recomputed by each filter function.

See `specs/bugfixes/streams-available-json-stale-ids/report.md` for the full bugfix report.

Fixes T-703