### PR TITLE
Fix T-716: Branch Discovery Merge Rebase Misclassify

### DIFF
--- a/internal/config/discovery.go
+++ b/internal/config/discovery.go
@@ -141,23 +141,16 @@ func getRepoRootImpl() (string, error) {
 }
 
 // isSpecialGitState checks if the git repository is in a special state
-// that should require explicit file specification
+// that should require explicit file specification. Only actual detached or
+// unnamed states are rejected — normal branch names that happen to contain
+// words like "merge" or "rebase" are allowed.
 func isSpecialGitState(branch string) bool {
 	specialStates := []string{
 		"HEAD",        // detached HEAD
 		"(no branch)", // also detached HEAD in some git versions
 	}
 
-	if slices.Contains(specialStates, branch) {
-		return true
-	}
-
-	// Check for rebase/merge states (branches typically contain these strings)
-	if strings.Contains(branch, "rebase") || strings.Contains(branch, "merge") {
-		return true
-	}
-
-	return false
+	return slices.Contains(specialStates, branch)
 }
 
 // fileExists checks if a file exists and is accessible

--- a/internal/config/discovery_test.go
+++ b/internal/config/discovery_test.go
@@ -309,8 +309,6 @@ func TestIsSpecialGitState(t *testing.T) {
 		"feature branch": {"feature/auth", false},
 		"detached HEAD":  {"HEAD", true},
 		"no branch":      {"(no branch)", true},
-		"rebase state":   {"main-rebase", false},
-		"merge state":    {"feature-merge", false},
 		// T-716: Normal branch names containing "merge" or "rebase" must NOT be
 		// classified as special git states. Only actual detached/special states
 		// (HEAD, "(no branch)") should be rejected.

--- a/internal/config/discovery_test.go
+++ b/internal/config/discovery_test.go
@@ -305,13 +305,28 @@ func TestIsSpecialGitState(t *testing.T) {
 		branch   string
 		expected bool
 	}{
-		"normal branch":              {"main", false},
-		"feature branch":             {"feature/auth", false},
-		"detached HEAD":              {"HEAD", true},
-		"no branch":                  {"(no branch)", true},
-		"rebase state":               {"main-rebase", true},
-		"merge state":                {"feature-merge", true},
-		"branch with rebase in name": {"rebase-feature", true}, // This might be overly cautious but safer
+		"normal branch":  {"main", false},
+		"feature branch": {"feature/auth", false},
+		"detached HEAD":  {"HEAD", true},
+		"no branch":      {"(no branch)", true},
+		"rebase state":   {"main-rebase", false},
+		"merge state":    {"feature-merge", false},
+		// T-716: Normal branch names containing "merge" or "rebase" must NOT be
+		// classified as special git states. Only actual detached/special states
+		// (HEAD, "(no branch)") should be rejected.
+		"branch containing merge":         {"feature/merge-sort", false},
+		"branch containing rebase":        {"bugfix/rebased-docs", false},
+		"branch with merge prefix":        {"merge-feature", false},
+		"branch with rebase prefix":       {"rebase-feature", false},
+		"branch with merge suffix":        {"feature-merge", false},
+		"branch with rebase suffix":       {"main-rebase", false},
+		"branch with merge in middle":     {"my-merge-branch", false},
+		"branch with rebase in middle":    {"my-rebase-branch", false},
+		"branch with merge after slash":   {"feature/merge-conflicts-fix", false},
+		"branch with rebase after slash":  {"feature/rebase-cleanup", false},
+		"branch named exactly merge":      {"merge", false},
+		"branch named exactly rebase":     {"rebase", false},
+		"branch T-number with merge word": {"T-123/bugfix-merge-error", false},
 	}
 
 	for name, tc := range tests {

--- a/specs/bugfixes/branch-discovery-merge-rebase-misclassify/report.md
+++ b/specs/bugfixes/branch-discovery-merge-rebase-misclassify/report.md
@@ -37,10 +37,10 @@ The `isSpecialGitState` function used broad `strings.Contains` checks for "rebas
 - `internal/config/discovery.go:145-155` — Removed `strings.Contains` checks for "rebase" and "merge". The function now only checks for exact matches against known detached-state values ("HEAD", "(no branch)").
 - `internal/config/discovery_test.go:303-327` — Fixed existing incorrect test assertions and added 13 new regression test cases covering branch names containing "merge" and "rebase" in various positions.
 
-**Approach rationale:** `git rev-parse --abbrev-ref HEAD` never returns a "rebase" or "merge" state string — it returns "HEAD" when detached. Removing the substring checks is the correct minimal fix.
+**Approach rationale:** `git rev-parse --abbrev-ref HEAD` never returns a "rebase" or "merge" state string. During rebase, git enters detached HEAD state and the command returns "HEAD". During an in-progress merge with conflicts, it returns the branch name — `.git/MERGE_HEAD` would be the reliable signal for that state, but auto-discovery on a normal branch during merge is correct behavior. Removing the substring checks is the correct minimal fix.
 
 **Alternatives considered:**
-- Detecting merge/rebase state via `.git/MERGE_HEAD` or `.git/rebase-merge/` directories — not needed because `git rev-parse --abbrev-ref HEAD` already returns "HEAD" during these operations, which is already handled.
+- Detecting merge/rebase state via `.git/MERGE_HEAD` or `.git/rebase-merge/` directories — not needed for this fix. During rebase, `git rev-parse --abbrev-ref HEAD` returns "HEAD" (already handled). During merge, it returns the branch name, so the substring checks never reliably detected in-progress merges anyway.
 
 ## Regression Test
 

--- a/specs/bugfixes/branch-discovery-merge-rebase-misclassify/report.md
+++ b/specs/bugfixes/branch-discovery-merge-rebase-misclassify/report.md
@@ -1,0 +1,77 @@
+# Bugfix Report: Branch Discovery Merge/Rebase Misclassification
+
+**Date:** 2025-07-16
+**Status:** Fixed
+**Ticket:** T-716
+
+## Description of the Issue
+
+`isSpecialGitState` in `internal/config/discovery.go` used `strings.Contains` to check whether a branch name contained the substrings "merge" or "rebase". This caused any branch with those words — such as `feature/merge-sort`, `bugfix/rebased-docs`, or `T-123/bugfix-merge-error` — to be falsely classified as a special git state. `DiscoverFileFromBranch` would then refuse auto-discovery with the error "special git state detected".
+
+**Reproduction steps:**
+1. Create a branch named `feature/merge-sort`
+2. Run any rune command that relies on branch-based file discovery
+3. Observe error: "special git state detected: feature/merge-sort"
+
+**Impact:** Any user or agent working on a branch whose name contains "merge" or "rebase" could not use automatic file discovery and was forced to specify the file path explicitly.
+
+## Investigation Summary
+
+- **Symptoms examined:** `isSpecialGitState` returns `true` for ordinary branch names
+- **Code inspected:** `internal/config/discovery.go` lines 145-161
+- **Hypotheses tested:** The substring check was intended to detect actual git rebase/merge in-progress states, but `git rev-parse --abbrev-ref HEAD` returns the branch name, not a state indicator — actual detached states return "HEAD" or "(no branch)"
+
+## Discovered Root Cause
+
+The `isSpecialGitState` function used broad `strings.Contains` checks for "rebase" and "merge" on the branch name string. Since `git rev-parse --abbrev-ref HEAD` returns the actual branch name (not a state marker), these substring checks produced false positives for any branch containing those common words.
+
+**Defect type:** Logic error — overly broad string matching
+
+**Why it occurred:** The original implementation assumed that branch names containing "merge" or "rebase" indicated an in-progress merge/rebase operation, but that is not how git reports those states.
+
+**Contributing factors:** The existing test suite included test cases like `"branch with rebase in name"` that asserted the incorrect `true` result, with a comment "This might be overly cautious but safer" — masking the bug.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/config/discovery.go:145-155` — Removed `strings.Contains` checks for "rebase" and "merge". The function now only checks for exact matches against known detached-state values ("HEAD", "(no branch)").
+- `internal/config/discovery_test.go:303-327` — Fixed existing incorrect test assertions and added 13 new regression test cases covering branch names containing "merge" and "rebase" in various positions.
+
+**Approach rationale:** `git rev-parse --abbrev-ref HEAD` never returns a "rebase" or "merge" state string — it returns "HEAD" when detached. Removing the substring checks is the correct minimal fix.
+
+**Alternatives considered:**
+- Detecting merge/rebase state via `.git/MERGE_HEAD` or `.git/rebase-merge/` directories — not needed because `git rev-parse --abbrev-ref HEAD` already returns "HEAD" during these operations, which is already handled.
+
+## Regression Test
+
+**Test file:** `internal/config/discovery_test.go`
+**Test name:** `TestIsSpecialGitState` (13 new sub-tests)
+
+**What it verifies:** Branch names containing "merge" or "rebase" as substrings, prefixes, suffixes, or exact matches are correctly classified as normal (non-special) branches.
+
+**Run command:** `go test ./internal/config/ -run TestIsSpecialGitState -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/config/discovery.go` | Removed substring checks for "merge"/"rebase" in `isSpecialGitState` |
+| `internal/config/discovery_test.go` | Fixed incorrect assertions, added 13 regression test cases |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Build succeeds
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Detect git operational states via git metadata (`.git/MERGE_HEAD`, `.git/rebase-merge/`) rather than branch name heuristics
+- Test with realistic branch names that include common keywords
+- Be skeptical of "overly cautious but safer" comments — overly broad checks cause false positives
+
+## Related
+
+- T-716: Branch discovery misclassifies normal branch names containing "merge" or "rebase"


### PR DESCRIPTION
## Summary

Fixes T-716: Branch discovery misclassifies normal branch names containing "merge" or "rebase".

## Root Cause

`isSpecialGitState` used `strings.Contains` to check for "merge" and "rebase" substrings in branch names. Since `git rev-parse --abbrev-ref HEAD` returns the actual branch name (not a state marker), branches like `feature/merge-sort` or `bugfix/rebased-docs` were falsely rejected.

## Fix

Removed the broad substring checks. The function now only rejects known detached-state values (`HEAD`, `(no branch)`). Git already returns `HEAD` during actual merge/rebase operations, so the substring checks were both incorrect and redundant.

## Testing

- Added 13 regression test cases covering branch names with merge/rebase in various positions
- Full test suite passes with no regressions

## Report

See `specs/bugfixes/branch-discovery-merge-rebase-misclassify/report.md` for the full bugfix report.