### PR TITLE
Fix T-725: complete/uncomplete --dry-run honours --format flag

### DIFF
--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -15,6 +15,8 @@ type CompleteResponse struct {
 	Message       string   `json:"message"`
 	TaskID        string   `json:"task_id"`
 	Title         string   `json:"title"`
+	DryRun        bool     `json:"dry_run"`
+	CurrentStatus string   `json:"current_status,omitempty"`
 	AutoCompleted []string `json:"auto_completed,omitempty"`
 }
 
@@ -87,12 +89,27 @@ func runComplete(cmd *cobra.Command, args []string) error {
 
 	// Dry run mode - just show what would be completed
 	if dryRun {
-		fmt.Printf("Would mark task as completed in file: %s\n", filename)
-		fmt.Printf("Task ID: %s\n", taskID)
-		fmt.Printf("Current status: %s\n", statusToString(targetTask.Status))
-		fmt.Printf("New status: completed\n")
-		fmt.Printf("Title: %s\n", targetTask.Title)
-		return nil
+		switch format {
+		case formatJSON:
+			return outputJSON(CompleteResponse{
+				Success:       true,
+				Message:       fmt.Sprintf("Would mark task %s as completed", taskID),
+				TaskID:        taskID,
+				Title:         targetTask.Title,
+				DryRun:        true,
+				CurrentStatus: statusToString(targetTask.Status),
+			})
+		case formatMarkdown:
+			fmt.Printf("**Dry run:** Would mark %s - %s as completed (currently %s)\n", taskID, targetTask.Title, statusToString(targetTask.Status))
+			return nil
+		default: // table
+			fmt.Printf("Would mark task as completed in file: %s\n", filename)
+			fmt.Printf("Task ID: %s\n", taskID)
+			fmt.Printf("Current status: %s\n", statusToString(targetTask.Status))
+			fmt.Printf("New status: completed\n")
+			fmt.Printf("Title: %s\n", targetTask.Title)
+			return nil
+		}
 	}
 
 	// Update the task status

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -15,7 +15,7 @@ type CompleteResponse struct {
 	Message       string   `json:"message"`
 	TaskID        string   `json:"task_id"`
 	Title         string   `json:"title"`
-	DryRun        bool     `json:"dry_run"`
+	DryRun        bool     `json:"dry_run,omitempty"`
 	CurrentStatus string   `json:"current_status,omitempty"`
 	AutoCompleted []string `json:"auto_completed,omitempty"`
 }

--- a/cmd/complete_test.go
+++ b/cmd/complete_test.go
@@ -483,6 +483,68 @@ func TestRunUncompleteDryRunJSON(t *testing.T) {
 	}
 }
 
+func TestRunUncompleteDryRunMarkdown(t *testing.T) {
+	tempDir := filepath.Join(".", "test-tmp-uncomplete-dry-md")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	filename := filepath.Join(tempDir, "test.md")
+
+	tl := task.NewTaskList("Test Tasks")
+	tl.AddTask("", "Completed task", "")
+	tl.UpdateStatus("1", task.Completed)
+	if err := tl.WriteFile(filename); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	dryRun = true
+	format = formatMarkdown
+	defer func() {
+		dryRun = false
+		format = "table"
+	}()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := &cobra.Command{}
+	args := []string{filename, "1"}
+	err := runUncomplete(cmd, args)
+
+	w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("Unexpected error in dry run: %v", err)
+	}
+
+	if !strings.Contains(output, "**Dry run:**") {
+		t.Fatalf("Expected markdown dry run output, got: %s", output)
+	}
+	if !strings.Contains(output, "pending") {
+		t.Fatalf("Expected output to mention 'pending', got: %s", output)
+	}
+
+	// Verify original file not modified
+	tl2, err := task.ParseFile(filename)
+	if err != nil {
+		t.Fatalf("Failed to parse file after dry run: %v", err)
+	}
+	foundTask := tl2.FindTask("1")
+	if foundTask == nil {
+		t.Fatal("Task 1 not found after dry run")
+	}
+	if foundTask.Status != task.Completed {
+		t.Fatalf("Expected task to remain completed after dry run, got status %d", foundTask.Status)
+	}
+}
+
 func TestRunUncomplete(t *testing.T) {
 	tempDir := filepath.Join(".", "test-tmp-uncomplete")
 	if err := os.MkdirAll(tempDir, 0755); err != nil {

--- a/cmd/complete_test.go
+++ b/cmd/complete_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -300,6 +301,186 @@ func TestRunCompleteDryRun(t *testing.T) {
 
 	// Reset dry run
 	dryRun = false
+}
+
+func TestRunCompleteDryRunJSON(t *testing.T) {
+	tempDir := filepath.Join(".", "test-tmp-complete-dry-json")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	filename := filepath.Join(tempDir, "test.md")
+
+	// Create test file with a pending task
+	tl := task.NewTaskList("Test Tasks")
+	tl.AddTask("", "Task to complete", "")
+	if err := tl.WriteFile(filename); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Set up dry run with JSON format
+	dryRun = true
+	format = formatJSON
+	defer func() {
+		dryRun = false
+		format = "table"
+	}()
+
+	// Capture output
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := &cobra.Command{}
+	args := []string{filename, "1"}
+	err := runComplete(cmd, args)
+
+	w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("Unexpected error in dry run: %v", err)
+	}
+
+	// Output must be valid JSON
+	var resp CompleteResponse
+	if err := json.Unmarshal([]byte(output), &resp); err != nil {
+		t.Fatalf("Dry-run --format json output is not valid JSON: %v\nGot: %s", err, output)
+	}
+
+	if !resp.DryRun {
+		t.Fatal("Expected dry_run to be true")
+	}
+	if resp.TaskID != "1" {
+		t.Fatalf("Expected task_id '1', got '%s'", resp.TaskID)
+	}
+	if resp.CurrentStatus != "pending" {
+		t.Fatalf("Expected current_status 'pending', got '%s'", resp.CurrentStatus)
+	}
+	if resp.Title != "Task to complete" {
+		t.Fatalf("Expected title 'Task to complete', got '%s'", resp.Title)
+	}
+	if !resp.Success {
+		t.Fatal("Expected success to be true")
+	}
+
+	// Verify file wasn't modified
+	tl2, err := task.ParseFile(filename)
+	if err != nil {
+		t.Fatalf("Failed to parse file after dry run: %v", err)
+	}
+	if tl2.Tasks[0].Status != task.Pending {
+		t.Fatal("File was modified during dry run")
+	}
+}
+
+func TestRunCompleteDryRunMarkdown(t *testing.T) {
+	tempDir := filepath.Join(".", "test-tmp-complete-dry-md")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	filename := filepath.Join(tempDir, "test.md")
+
+	tl := task.NewTaskList("Test Tasks")
+	tl.AddTask("", "Task to complete", "")
+	if err := tl.WriteFile(filename); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	dryRun = true
+	format = formatMarkdown
+	defer func() {
+		dryRun = false
+		format = "table"
+	}()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := &cobra.Command{}
+	args := []string{filename, "1"}
+	err := runComplete(cmd, args)
+
+	w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("Unexpected error in dry run: %v", err)
+	}
+
+	if !strings.Contains(output, "**Dry run:**") {
+		t.Fatalf("Expected markdown dry run output, got: %s", output)
+	}
+	if !strings.Contains(output, "completed") {
+		t.Fatalf("Expected output to mention 'completed', got: %s", output)
+	}
+}
+
+func TestRunUncompleteDryRunJSON(t *testing.T) {
+	tempDir := filepath.Join(".", "test-tmp-uncomplete-dry-json")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	filename := filepath.Join(tempDir, "test.md")
+
+	tl := task.NewTaskList("Test Tasks")
+	tl.AddTask("", "Completed task", "")
+	tl.UpdateStatus("1", task.Completed)
+	if err := tl.WriteFile(filename); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	dryRun = true
+	format = formatJSON
+	defer func() {
+		dryRun = false
+		format = "table"
+	}()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := &cobra.Command{}
+	args := []string{filename, "1"}
+	err := runUncomplete(cmd, args)
+
+	w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("Unexpected error in dry run: %v", err)
+	}
+
+	var resp UncompleteResponse
+	if err := json.Unmarshal([]byte(output), &resp); err != nil {
+		t.Fatalf("Dry-run --format json output is not valid JSON: %v\nGot: %s", err, output)
+	}
+
+	if !resp.DryRun {
+		t.Fatal("Expected dry_run to be true")
+	}
+	if resp.TaskID != "1" {
+		t.Fatalf("Expected task_id '1', got '%s'", resp.TaskID)
+	}
+	if resp.CurrentStatus != "completed" {
+		t.Fatalf("Expected current_status 'completed', got '%s'", resp.CurrentStatus)
+	}
 }
 
 func TestRunUncomplete(t *testing.T) {

--- a/cmd/uncomplete.go
+++ b/cmd/uncomplete.go
@@ -14,7 +14,7 @@ type UncompleteResponse struct {
 	Message       string `json:"message"`
 	TaskID        string `json:"task_id"`
 	Title         string `json:"title"`
-	DryRun        bool   `json:"dry_run"`
+	DryRun        bool   `json:"dry_run,omitempty"`
 	CurrentStatus string `json:"current_status,omitempty"`
 }
 

--- a/cmd/uncomplete.go
+++ b/cmd/uncomplete.go
@@ -10,10 +10,12 @@ import (
 
 // UncompleteResponse is the JSON response for the uncomplete command
 type UncompleteResponse struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-	TaskID  string `json:"task_id"`
-	Title   string `json:"title"`
+	Success       bool   `json:"success"`
+	Message       string `json:"message"`
+	TaskID        string `json:"task_id"`
+	Title         string `json:"title"`
+	DryRun        bool   `json:"dry_run"`
+	CurrentStatus string `json:"current_status,omitempty"`
 }
 
 var uncompleteCmd = &cobra.Command{
@@ -83,12 +85,27 @@ func runUncomplete(cmd *cobra.Command, args []string) error {
 
 	// Dry run mode - just show what would be uncompleted
 	if dryRun {
-		fmt.Printf("Would mark task as pending in file: %s\n", filename)
-		fmt.Printf("Task ID: %s\n", taskID)
-		fmt.Printf("Current status: %s\n", statusToString(targetTask.Status))
-		fmt.Printf("New status: pending\n")
-		fmt.Printf("Title: %s\n", targetTask.Title)
-		return nil
+		switch format {
+		case formatJSON:
+			return outputJSON(UncompleteResponse{
+				Success:       true,
+				Message:       fmt.Sprintf("Would mark task %s as pending", taskID),
+				TaskID:        taskID,
+				Title:         targetTask.Title,
+				DryRun:        true,
+				CurrentStatus: statusToString(targetTask.Status),
+			})
+		case formatMarkdown:
+			fmt.Printf("**Dry run:** Would mark %s - %s as pending (currently %s)\n", taskID, targetTask.Title, statusToString(targetTask.Status))
+			return nil
+		default: // table
+			fmt.Printf("Would mark task as pending in file: %s\n", filename)
+			fmt.Printf("Task ID: %s\n", taskID)
+			fmt.Printf("Current status: %s\n", statusToString(targetTask.Status))
+			fmt.Printf("New status: pending\n")
+			fmt.Printf("Title: %s\n", targetTask.Title)
+			return nil
+		}
 	}
 
 	// Update the task status

--- a/specs/bugfixes/complete-dry-run-json/report.md
+++ b/specs/bugfixes/complete-dry-run-json/report.md
@@ -1,0 +1,78 @@
+# Bugfix Report: complete-dry-run-json
+
+**Date:** 2026-04-16
+**Status:** Fixed
+**Ticket:** T-725
+
+## Description of the Issue
+
+`rune complete --dry-run --format json` emits plain text instead of JSON. The dry-run code path in `runComplete` (and `runUncomplete`) used `fmt.Printf` unconditionally, bypassing the format-aware output switch that the non-dry-run path uses.
+
+**Reproduction steps:**
+1. Create a task file: `rune create test.md --title "Test"`
+2. Add a task: `rune add test.md --title "Task 1"`
+3. Run: `rune complete --dry-run --format json test.md 1`
+4. Observe output is plain text lines instead of a JSON object
+
+**Impact:** Breaks automation/scripts that parse JSON output and rely on dry-run safety. The `--format markdown` flag was also ignored in dry-run mode.
+
+## Investigation Summary
+
+- **Symptoms examined:** Dry-run output was always plain text regardless of `--format` flag
+- **Code inspected:** `cmd/complete.go`, `cmd/uncomplete.go`, `cmd/progress.go` (which correctly handles this)
+- **Hypotheses tested:** Confirmed the dry-run branch simply never checked the `format` variable
+
+## Discovered Root Cause
+
+The dry-run branch in `runComplete` and `runUncomplete` used `fmt.Printf` directly without a `switch format` block, unlike the non-dry-run path and unlike `runProgress` which correctly handles all formats in dry-run mode.
+
+**Defect type:** Missing format dispatch in code path
+
+**Why it occurred:** The dry-run path was likely written before format-aware output was added, and was not updated when the format switch was added to the non-dry-run path.
+
+**Contributing factors:** `progress.go` was implemented correctly, suggesting the pattern was known but not applied consistently.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/complete.go` — Added `switch format` block to dry-run path, matching the pattern used by `progress.go`. Added `DryRun` and `CurrentStatus` fields to `CompleteResponse`.
+- `cmd/uncomplete.go` — Same fix applied. Added `DryRun` and `CurrentStatus` fields to `UncompleteResponse`.
+
+**Approach rationale:** Followed the existing pattern from `progress.go` for consistency across all status-changing commands.
+
+**Alternatives considered:**
+- Extract a shared dry-run helper — not chosen because each command has slightly different response structs and messages.
+
+## Regression Test
+
+**Test file:** `cmd/complete_test.go`
+**Test names:** `TestRunCompleteDryRunJSON`, `TestRunCompleteDryRunMarkdown`, `TestRunUncompleteDryRunJSON`
+
+**What it verifies:** Dry-run output is valid JSON when `--format json` is used, and contains expected markdown when `--format markdown` is used. Also verifies the file is not modified.
+
+**Run command:** `go test -run "TestRunCompleteDryRunJSON|TestRunCompleteDryRunMarkdown|TestRunUncompleteDryRunJSON" -v ./cmd`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/complete.go` | Added format-aware dry-run output; added `DryRun`/`CurrentStatus` fields to `CompleteResponse` |
+| `cmd/uncomplete.go` | Added format-aware dry-run output; added `DryRun`/`CurrentStatus` fields to `UncompleteResponse` |
+| `cmd/complete_test.go` | Added 3 regression tests for dry-run JSON/markdown output |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Code formatted with `make fmt`
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding a new code path (like dry-run), ensure it respects the same format dispatch as the primary path
+- Consider a linter rule or code review checklist item: "Does every user-facing output path honour `--format`?"
+
+## Related
+
+- T-725: `complete --dry-run --format json` emits plain text instead of JSON


### PR DESCRIPTION
## Bug

`rune complete --dry-run --format json` emitted plain text instead of JSON. Same issue in `uncomplete`.

## Root Cause

The dry-run code path used `fmt.Printf` unconditionally, bypassing the `switch format` block that the non-dry-run path uses. The `progress` command already handled this correctly.

## Fix

- Added format-aware `switch format` to the dry-run branch in both `runComplete` and `runUncomplete`, matching the pattern from `runProgress`
- Added `DryRun` and `CurrentStatus` fields to `CompleteResponse` and `UncompleteResponse`
- Added 3 regression tests

## Verification

- All regression tests pass
- Full test suite passes (`make test`)

See `specs/bugfixes/complete-dry-run-json/report.md` for full details.

Fixes T-725