### PR TITLE
Fix T-742: Phase Lookup Breaks With Non-Sequential Markdown IDs

### DIFF
--- a/internal/task/parse.go
+++ b/internal/task/parse.go
@@ -521,9 +521,12 @@ func countIndent(line string) int {
 
 // ExtractPhaseMarkers scans lines for H2 headers and returns phase markers with their positions.
 // Lines may contain trailing \r from CRLF files; these are stripped before matching.
+// AfterTaskID stores sequential positional IDs (matching parsed task IDs) rather than
+// raw markdown IDs, so that downstream consumers can compare directly against TaskList.Tasks[i].ID.
 func ExtractPhaseMarkers(lines []string) []PhaseMarker {
 	markers := []PhaseMarker{}
-	var lastTaskID string
+	var lastSequentialID string
+	topLevelTaskCount := 0
 
 	for _, line := range lines {
 		line = strings.TrimRight(line, "\r")
@@ -533,17 +536,18 @@ func ExtractPhaseMarkers(lines []string) []PhaseMarker {
 			phaseName := strings.TrimSpace(matches[1])
 			markers = append(markers, PhaseMarker{
 				Name:        phaseName,
-				AfterTaskID: lastTaskID,
+				AfterTaskID: lastSequentialID,
 			})
 		} else if _, ok, err := parseTaskLine(line); err == nil && ok {
 			// Extract task ID from the line
 			// The task ID is captured in the regex pattern
 			if taskMatches := taskLinePattern.FindStringSubmatch(line); len(taskMatches) >= 4 {
-				// Only update lastTaskID for top-level tasks (not subtasks)
+				// Only update lastSequentialID for top-level tasks (not subtasks)
 				// Top-level tasks don't have dots in their IDs
 				taskID := taskMatches[3]
 				if !strings.Contains(taskID, ".") {
-					lastTaskID = taskID
+					topLevelTaskCount++
+					lastSequentialID = fmt.Sprintf("%d", topLevelTaskCount)
 				}
 			}
 		}

--- a/internal/task/phase_test.go
+++ b/internal/task/phase_test.go
@@ -1423,3 +1423,148 @@ func TestGetNextPhaseTasks_NonSequentialIDs(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractPhaseMarkers_NonSequentialIDs verifies that ExtractPhaseMarkers
+// stores sequential positional IDs in AfterTaskID, not raw markdown IDs.
+// Regression test for T-742.
+func TestExtractPhaseMarkers_NonSequentialIDs(t *testing.T) {
+	tests := map[string]struct {
+		content     string
+		wantMarkers []PhaseMarker
+	}{
+		"non-sequential IDs produce sequential AfterTaskID": {
+			content: `# Project
+## Phase A
+- [ ] 10. First task
+- [ ] 20. Second task
+
+## Phase B
+- [ ] 30. Third task
+`,
+			wantMarkers: []PhaseMarker{
+				{Name: "Phase A", AfterTaskID: ""},
+				{Name: "Phase B", AfterTaskID: "2"},
+			},
+		},
+		"large gap IDs": {
+			content: `# Project
+- [ ] 100. Pre-phase task
+
+## Development
+- [ ] 200. Dev task
+- [ ] 300. Dev task 2
+
+## Testing
+- [ ] 400. Test task
+`,
+			wantMarkers: []PhaseMarker{
+				{Name: "Development", AfterTaskID: "1"},
+				{Name: "Testing", AfterTaskID: "3"},
+			},
+		},
+		"non-sequential with subtasks": {
+			content: `# Project
+## Phase One
+- [ ] 10. Parent task
+  - [ ] 10.1. Subtask
+
+## Phase Two
+- [ ] 20. Next parent
+`,
+			wantMarkers: []PhaseMarker{
+				{Name: "Phase One", AfterTaskID: ""},
+				{Name: "Phase Two", AfterTaskID: "1"},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lines := splitLines(tc.content)
+			markers := ExtractPhaseMarkers(lines)
+
+			if !reflect.DeepEqual(markers, tc.wantMarkers) {
+				t.Errorf("ExtractPhaseMarkers() mismatch:\ngot:  %+v\nwant: %+v", markers, tc.wantMarkers)
+			}
+		})
+	}
+}
+
+// TestGetTaskPhase_NonSequentialMarkdownIDs verifies that GetTaskPhase in render.go
+// correctly assigns phases when phase markers come from non-sequential markdown IDs.
+// Regression test for T-742.
+func TestGetTaskPhase_NonSequentialMarkdownIDs(t *testing.T) {
+	// Simulate what happens after ParseMarkdown: tasks have sequential IDs 1, 2, 3
+	// Phase markers should also have sequential AfterTaskIDs from ExtractPhaseMarkers
+	tl := &TaskList{
+		Tasks: []Task{
+			{ID: "1", Title: "First task"},
+			{ID: "2", Title: "Second task"},
+			{ID: "3", Title: "Third task"},
+		},
+	}
+
+	// These markers represent what ExtractPhaseMarkers produces from a file
+	// with non-sequential IDs (10, 20, 30) — now stored as sequential (1, 2, 3)
+	markers := []PhaseMarker{
+		{Name: "Phase A", AfterTaskID: ""},
+		{Name: "Phase B", AfterTaskID: "2"},
+	}
+
+	tests := map[string]struct {
+		taskID    string
+		wantPhase string
+	}{
+		"task 1 in Phase A": {taskID: "1", wantPhase: "Phase A"},
+		"task 2 in Phase A": {taskID: "2", wantPhase: "Phase A"},
+		"task 3 in Phase B": {taskID: "3", wantPhase: "Phase B"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GetTaskPhase(tl, markers, tc.taskID)
+			if got != tc.wantPhase {
+				t.Errorf("GetTaskPhase(%q) = %q, want %q", tc.taskID, got, tc.wantPhase)
+			}
+		})
+	}
+}
+
+// TestRenderMarkdownWithPhases_NonSequentialIDs verifies that
+// RenderMarkdownWithPhases correctly places phase headers when the original
+// markdown had non-sequential IDs that were renumbered by the parser.
+// Regression test for T-742.
+func TestRenderMarkdownWithPhases_NonSequentialIDs(t *testing.T) {
+	tl := &TaskList{
+		Title: "Non-Sequential Project",
+		Tasks: []Task{
+			{ID: "1", Title: "First task", Status: Pending},
+			{ID: "2", Title: "Second task", Status: InProgress},
+			{ID: "3", Title: "Third task", Status: Pending},
+		},
+	}
+
+	// Markers with sequential AfterTaskIDs (as produced by fixed ExtractPhaseMarkers)
+	markers := []PhaseMarker{
+		{Name: "Phase A", AfterTaskID: ""},
+		{Name: "Phase B", AfterTaskID: "2"},
+	}
+
+	got := string(RenderMarkdownWithPhases(tl, markers))
+	want := `# Non-Sequential Project
+
+## Phase A
+
+- [ ] 1. First task
+
+- [-] 2. Second task
+
+## Phase B
+
+- [ ] 3. Third task
+`
+
+	if got != want {
+		t.Errorf("RenderMarkdownWithPhases() mismatch:\nGot:\n%s\nWant:\n%s", got, want)
+	}
+}

--- a/specs/bugfixes/phase-lookup-nonsequential-ids/report.md
+++ b/specs/bugfixes/phase-lookup-nonsequential-ids/report.md
@@ -1,0 +1,76 @@
+# Bugfix Report: phase-lookup-nonsequential-ids
+
+**Date:** 2026-04-16
+**Status:** Fixed
+
+## Description of the Issue
+
+Phase labeling in `rune list` output (table, JSON, markdown) was incorrect when task files contained non-sequential top-level markdown IDs (e.g., `10`, `20`, `30`). Phase boundaries were never matched because `ExtractPhaseMarkers` stored raw markdown IDs while parsed tasks used sequential IDs.
+
+**Reproduction steps:**
+1. Create a task file with phases and non-sequential top-level task IDs (e.g., `10`, `20`, `30`)
+2. Run `rune list` with phase-aware output
+3. Observe phase assignment does not switch at expected boundaries
+
+**Impact:** Incorrect or missing phase values in all output formats when task files contain non-sequential IDs.
+
+## Investigation Summary
+
+- **Symptoms examined:** Phase labels missing or incorrect in list outputs
+- **Code inspected:** `internal/task/parse.go` (`ExtractPhaseMarkers`), `internal/task/render.go` (`GetTaskPhase`, `RenderMarkdownWithPhases`), `internal/task/phase.go` (`getTaskPhase`, `buildTaskPhaseMap`)
+- **Hypotheses tested:** Confirmed that `AfterTaskID` stored raw markdown IDs while consumers compared against sequential parsed IDs
+
+## Discovered Root Cause
+
+`ExtractPhaseMarkers` stored the raw markdown task ID (e.g., `"10"`) in `PhaseMarker.AfterTaskID`, but `ParseMarkdown` renumbers all tasks sequentially (`"1"`, `"2"`, ...). Downstream functions (`GetTaskPhase`, `RenderMarkdownWithPhases`) compared `AfterTaskID` against `tl.Tasks[i].ID` (sequential), so boundaries with non-sequential raw IDs never matched.
+
+**Defect type:** ID domain mismatch — raw IDs vs sequential parsed IDs
+
+**Why it occurred:** `ExtractPhaseMarkers` was written to capture the literal task ID from markdown text, without accounting for the renumbering that `ParseMarkdown` performs.
+
+**Contributing factors:** The functions in `phase.go` (`getTaskPhase`, `buildTaskPhaseMap`) independently implemented positional counting and worked correctly, masking the fact that `ExtractPhaseMarkers` itself was producing incompatible IDs.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/parse.go:526-558` - Changed `ExtractPhaseMarkers` to track a positional counter for top-level tasks and store sequential IDs in `AfterTaskID` instead of raw markdown IDs
+
+**Approach rationale:** Fixing `ExtractPhaseMarkers` at the source ensures all downstream consumers (`GetTaskPhase`, `RenderMarkdownWithPhases`, `RenderJSONWithPhases`) automatically work correctly without individual fixes.
+
+**Alternatives considered:**
+- Fix each consumer individually to do positional mapping — rejected because it's more code, more error-prone, and doesn't fix the root cause
+
+## Regression Test
+
+**Test file:** `internal/task/phase_test.go`
+**Test names:**
+- `TestExtractPhaseMarkers_NonSequentialIDs` — verifies `AfterTaskID` is sequential
+- `TestGetTaskPhase_NonSequentialMarkdownIDs` — verifies `GetTaskPhase` returns correct phases
+- `TestRenderMarkdownWithPhases_NonSequentialIDs` — verifies markdown rendering places phase headers correctly
+
+**Run command:** `go test ./internal/task/ -run "NonSequential" -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/parse.go` | `ExtractPhaseMarkers` now stores sequential positional IDs |
+| `internal/task/phase_test.go` | Added 3 regression test functions for T-742 |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass (fmt)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When functions produce IDs, document whether they are raw markdown IDs or sequential parsed IDs
+- Prefer a single ID domain throughout the pipeline to avoid mismatches
+
+## Related
+
+- T-604: Previous fix for `getTaskPhase`/`buildTaskPhaseMap` (positional counting in `phase.go`)
+- T-742: This bug (the same fix was needed in `ExtractPhaseMarkers` for render.go consumers)


### PR DESCRIPTION
## Bug

Phase labeling in `rune list` output was incorrect when task files contained non-sequential top-level markdown IDs (e.g., `10`, `20`, `30`).

## Root Cause

`ExtractPhaseMarkers` stored raw markdown task IDs in `AfterTaskID`, but `ParseMarkdown` renumbers tasks sequentially. Downstream functions (`GetTaskPhase`, `RenderMarkdownWithPhases`) compared raw IDs against sequential IDs — they never matched.

## Fix

Changed `ExtractPhaseMarkers` to track a positional counter and store sequential IDs, matching the domain used by all consumers.

## Testing

- 3 new regression tests for T-742 (ExtractPhaseMarkers, GetTaskPhase, RenderMarkdownWithPhases with non-sequential IDs)
- Full test suite passes

See `specs/bugfixes/phase-lookup-nonsequential-ids/report.md` for details.