### PR TITLE
Fix T-780: Add/Update paths bypass 500-char task title limit

### DIFF
--- a/internal/task/batch.go
+++ b/internal/task/batch.go
@@ -231,8 +231,8 @@ func validateOperation(tl *TaskList, op Operation) error {
 		if op.Title == "" {
 			return fmt.Errorf("add operation requires title")
 		}
-		if len(op.Title) > 500 {
-			return fmt.Errorf("title exceeds 500 characters")
+		if len(op.Title) > MaxTitleLength {
+			return fmt.Errorf("title exceeds %d characters", MaxTitleLength)
 		}
 		if op.Parent != "" && tl.FindTask(op.Parent) == nil {
 			return fmt.Errorf("parent task %s not found", op.Parent)
@@ -271,8 +271,8 @@ func validateOperation(tl *TaskList, op Operation) error {
 		if tl.FindTask(op.ID) == nil {
 			return fmt.Errorf("task %s not found", op.ID)
 		}
-		if op.Title != "" && len(op.Title) > 500 {
-			return fmt.Errorf("title exceeds 500 characters")
+		if op.Title != "" && len(op.Title) > MaxTitleLength {
+			return fmt.Errorf("title exceeds %d characters", MaxTitleLength)
 		}
 		// Validate status only when status field is provided
 		if hasStatusField(op) && (*op.Status < Pending || *op.Status > Completed) {

--- a/internal/task/batch.go
+++ b/internal/task/batch.go
@@ -232,7 +232,7 @@ func validateOperation(tl *TaskList, op Operation) error {
 			return fmt.Errorf("add operation requires title")
 		}
 		if len(op.Title) > MaxTitleLength {
-			return fmt.Errorf("title exceeds %d characters", MaxTitleLength)
+			return fmt.Errorf("task title exceeds %d characters", MaxTitleLength)
 		}
 		if op.Parent != "" && tl.FindTask(op.Parent) == nil {
 			return fmt.Errorf("parent task %s not found", op.Parent)
@@ -272,7 +272,7 @@ func validateOperation(tl *TaskList, op Operation) error {
 			return fmt.Errorf("task %s not found", op.ID)
 		}
 		if op.Title != "" && len(op.Title) > MaxTitleLength {
-			return fmt.Errorf("title exceeds %d characters", MaxTitleLength)
+			return fmt.Errorf("task title exceeds %d characters", MaxTitleLength)
 		}
 		// Validate status only when status field is provided
 		if hasStatusField(op) && (*op.Status < Pending || *op.Status > Completed) {

--- a/internal/task/operations.go
+++ b/internal/task/operations.go
@@ -14,6 +14,7 @@ import (
 const (
 	MaxTaskCount      = 10000 // Maximum number of tasks
 	MaxHierarchyDepth = 10    // Maximum hierarchy depth
+	MaxTitleLength    = 500   // Maximum characters per task title
 	MaxDetailLength   = 1000  // Maximum characters per detail line
 )
 
@@ -438,7 +439,10 @@ func validateTaskInput(input string) error {
 		return fmt.Errorf("input contains null bytes or control characters")
 	}
 
-	// Length validation is handled by Task.Validate()
+	if len(input) > MaxTitleLength {
+		return fmt.Errorf("task title exceeds %d characters", MaxTitleLength)
+	}
+
 	return nil
 }
 

--- a/internal/task/operations_test.go
+++ b/internal/task/operations_test.go
@@ -1454,3 +1454,63 @@ func TestParentChildRelationshipIntegrity(t *testing.T) {
 		}
 	})
 }
+
+func TestTitleLengthValidation(t *testing.T) {
+	longTitle := strings.Repeat("a", MaxTitleLength+1)
+	exactTitle := strings.Repeat("a", MaxTitleLength)
+	wantErr := fmt.Sprintf("task title exceeds %d characters", MaxTitleLength)
+
+	t.Run("AddTask rejects title exceeding max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTask("", longTitle, "")
+		if err == nil {
+			t.Fatal("expected error for oversized title, got nil")
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+		}
+	})
+
+	t.Run("AddTask accepts title at max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTask("", exactTitle, "")
+		if err != nil {
+			t.Fatalf("expected no error for title at max length, got %v", err)
+		}
+	})
+
+	t.Run("UpdateTask rejects title exceeding max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, _ = tl.AddTask("", "Valid title", "")
+		err := tl.UpdateTask("1", longTitle, nil, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for oversized title, got nil")
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+		}
+	})
+
+	t.Run("AddTaskWithOptions rejects title exceeding max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTaskWithOptions("", longTitle, AddOptions{})
+		if err == nil {
+			t.Fatal("expected error for oversized title, got nil")
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+		}
+	})
+
+	t.Run("UpdateTaskWithOptions rejects title exceeding max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, _ = tl.AddTask("", "Valid title", "")
+		err := tl.UpdateTaskWithOptions("1", UpdateOptions{Title: &longTitle})
+		if err == nil {
+			t.Fatal("expected error for oversized title, got nil")
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+		}
+	})
+}

--- a/internal/task/operations_test.go
+++ b/internal/task/operations_test.go
@@ -1491,6 +1491,15 @@ func TestTitleLengthValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("UpdateTask accepts title at max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, _ = tl.AddTask("", "Valid title", "")
+		err := tl.UpdateTask("1", exactTitle, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected no error for title at max length, got %v", err)
+		}
+	})
+
 	t.Run("AddTaskWithOptions rejects title exceeding max length", func(t *testing.T) {
 		tl := &TaskList{Title: "Test"}
 		_, err := tl.AddTaskWithOptions("", longTitle, AddOptions{})
@@ -1499,6 +1508,14 @@ func TestTitleLengthValidation(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), wantErr) {
 			t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+		}
+	})
+
+	t.Run("AddTaskWithOptions accepts title at max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTaskWithOptions("", exactTitle, AddOptions{})
+		if err != nil {
+			t.Fatalf("expected no error for title at max length, got %v", err)
 		}
 	})
 
@@ -1511,6 +1528,15 @@ func TestTitleLengthValidation(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), wantErr) {
 			t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+		}
+	})
+
+	t.Run("UpdateTaskWithOptions accepts title at max length", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, _ = tl.AddTask("", "Valid title", "")
+		err := tl.UpdateTaskWithOptions("1", UpdateOptions{Title: &exactTitle})
+		if err != nil {
+			t.Fatalf("expected no error for title at max length, got %v", err)
 		}
 	})
 }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -134,8 +134,8 @@ func (t *Task) Validate() error {
 	if t.Title == "" {
 		return fmt.Errorf("task title cannot be empty")
 	}
-	if len(t.Title) > 500 {
-		return fmt.Errorf("task title exceeds 500 characters")
+	if len(t.Title) > MaxTitleLength {
+		return fmt.Errorf("task title exceeds %d characters", MaxTitleLength)
 	}
 	if !IsValidID(t.ID) {
 		return fmt.Errorf("invalid task ID format: %s", t.ID)

--- a/specs/bugfixes/add-update-bypass-title-limit/report.md
+++ b/specs/bugfixes/add-update-bypass-title-limit/report.md
@@ -1,0 +1,75 @@
+# Bugfix Report: add-update-bypass-title-limit
+
+**Date:** 2026-04-16
+**Status:** Fixed
+
+## Description of the Issue
+
+The 500-character task title limit was only enforced in batch operations (`batch.go`) and `Task.Validate()`, but not in the direct add/update code paths. This meant CLI `add` and `update` commands could persist oversized titles while batch calls rejected them.
+
+**Reproduction steps:**
+1. Create a task file: `rune create test.md --title "Test"`
+2. Add a task with a 501+ character title: `rune add test.md --title "<501 chars>"`
+3. The task is accepted despite exceeding the limit
+
+**Impact:** Inconsistent validation across entry points; oversized titles could be persisted through non-batch operations.
+
+## Investigation Summary
+
+- **Symptoms examined:** `validateTaskInput` in `operations.go` only checked for null bytes, not title length
+- **Code inspected:** `operations.go` (validateTaskInput, AddTask, UpdateTask, AddTaskWithOptions, UpdateTaskWithOptions), `batch.go` (hardcoded 500 checks), `task.go` (Task.Validate)
+- **Hypotheses tested:** Confirmed that `Task.Validate()` was never called in the add/update paths after setting the title
+
+## Discovered Root Cause
+
+`validateTaskInput()` contained a comment "Length validation is handled by Task.Validate()" but `Task.Validate()` was never invoked in the add/update operation paths. The batch operations had their own separate inline length checks.
+
+**Defect type:** Missing validation
+
+**Why it occurred:** The validation was split across multiple locations with an incorrect assumption that `Task.Validate()` would be called downstream.
+
+**Contributing factors:** Lack of a single shared validation constant — the limit was hardcoded as `500` in three separate locations.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/operations.go:16` - Added `MaxTitleLength = 500` constant
+- `internal/task/operations.go:390-396` - Added length check to `validateTaskInput()`, removed misleading comment
+- `internal/task/task.go:137-138` - Use `MaxTitleLength` constant instead of hardcoded `500`
+- `internal/task/batch.go:234-235,274-275` - Use `MaxTitleLength` constant instead of hardcoded `500`
+
+**Approach rationale:** Centralizing the validation in `validateTaskInput()` ensures all add/update code paths enforce the limit consistently. Introducing a named constant eliminates magic numbers.
+
+**Alternatives considered:**
+- Calling `Task.Validate()` after each mutation — heavier and would require constructing a Task object before validation in some paths.
+
+## Regression Test
+
+**Test file:** `internal/task/operations_test.go`
+**Test name:** `TestTitleLengthValidation`
+
+**What it verifies:** All four entry points (AddTask, UpdateTask, AddTaskWithOptions, UpdateTaskWithOptions) reject titles exceeding MaxTitleLength and accept titles at exactly MaxTitleLength.
+
+**Run command:** `go test -run TestTitleLengthValidation -v ./internal/task/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/operations.go` | Added `MaxTitleLength` constant; added length check to `validateTaskInput` |
+| `internal/task/task.go` | Use `MaxTitleLength` constant in `Task.Validate()` |
+| `internal/task/batch.go` | Use `MaxTitleLength` constant in batch validation |
+| `internal/task/operations_test.go` | Added `TestTitleLengthValidation` regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`make test`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Use named constants for all validation limits to enable single-point-of-change
+- Validate inputs at the shared helper level rather than at individual call sites
+- Integration tests should cover all entry points for the same validation rule


### PR DESCRIPTION
## Bug

`validateTaskInput()` only checked for null bytes/control characters but did not enforce the 500-character title limit. CLI `add`/`update` commands and direct API callers could persist oversized titles, while batch operations correctly rejected them.

## Root Cause

The comment in `validateTaskInput()` claimed "Length validation is handled by Task.Validate()" but `Task.Validate()` was never called in the add/update operation paths.

## Fix

- Added `MaxTitleLength` constant (500) to replace hardcoded magic numbers
- Added length check to `validateTaskInput()` — the shared validator used by all add/update paths
- Updated `Task.Validate()` and batch validation to use the constant

## Tests

Added `TestTitleLengthValidation` with subtests covering all four entry points: AddTask, UpdateTask, AddTaskWithOptions, UpdateTaskWithOptions.

See full report: `specs/bugfixes/add-update-bypass-title-limit/report.md`