### PR TITLE
Fix T-781: Task Input Embedded Newlines

### DIFF
--- a/internal/task/operations.go
+++ b/internal/task/operations.go
@@ -485,10 +485,13 @@ func validateRequirements(requirements []string) error {
 	return nil
 }
 
-// containsNullByte checks for null bytes and dangerous control characters
+// containsNullByte checks for null bytes and dangerous control characters.
+// Rejects all control characters below U+0020 except horizontal tab (\t).
+// Notably, \n and \r are rejected because they break markdown line structure
+// when embedded in titles, details, or references.
 func containsNullByte(s string) bool {
 	for _, r := range s {
-		if r == 0 || (r < 32 && r != '\t' && r != '\n' && r != '\r') {
+		if r == 0 || (r < 32 && r != '\t') {
 			return true
 		}
 	}

--- a/internal/task/operations_test.go
+++ b/internal/task/operations_test.go
@@ -1545,11 +1545,16 @@ func TestTitleLengthValidation(t *testing.T) {
 // are rejected in titles, details, and references to prevent markdown corruption.
 // Regression test for T-781.
 func TestEmbeddedNewlinesRejected(t *testing.T) {
+	const errSubstring = "control characters"
+
 	t.Run("AddTask rejects title with newline", func(t *testing.T) {
 		tl := &TaskList{Title: "Test"}
 		_, err := tl.AddTask("", "line1\nline2", "")
 		if err == nil {
 			t.Fatal("expected error for title containing \\n, got nil")
+		}
+		if !strings.Contains(err.Error(), errSubstring) {
+			t.Errorf("error %q should mention %q", err, errSubstring)
 		}
 	})
 
@@ -1558,6 +1563,9 @@ func TestEmbeddedNewlinesRejected(t *testing.T) {
 		_, err := tl.AddTask("", "line1\rline2", "")
 		if err == nil {
 			t.Fatal("expected error for title containing \\r, got nil")
+		}
+		if !strings.Contains(err.Error(), errSubstring) {
+			t.Errorf("error %q should mention %q", err, errSubstring)
 		}
 	})
 
@@ -1571,7 +1579,9 @@ func TestEmbeddedNewlinesRejected(t *testing.T) {
 
 	t.Run("UpdateTask rejects title with newline", func(t *testing.T) {
 		tl := &TaskList{Title: "Test"}
-		tl.AddTask("", "Valid task", "")
+		if _, err := tl.AddTask("", "Valid task", ""); err != nil {
+			t.Fatalf("test setup failed: %v", err)
+		}
 
 		err := tl.UpdateTask("1", "new\ntitle", nil, nil, nil)
 		if err == nil {
@@ -1581,7 +1591,9 @@ func TestEmbeddedNewlinesRejected(t *testing.T) {
 
 	t.Run("UpdateTask rejects details with newline", func(t *testing.T) {
 		tl := &TaskList{Title: "Test"}
-		tl.AddTask("", "Valid task", "")
+		if _, err := tl.AddTask("", "Valid task", ""); err != nil {
+			t.Fatalf("test setup failed: %v", err)
+		}
 
 		err := tl.UpdateTask("1", "", []string{"detail\ninjection"}, nil, nil)
 		if err == nil {
@@ -1589,9 +1601,23 @@ func TestEmbeddedNewlinesRejected(t *testing.T) {
 		}
 	})
 
+	t.Run("UpdateTask rejects details with CRLF", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		if _, err := tl.AddTask("", "Valid task", ""); err != nil {
+			t.Fatalf("test setup failed: %v", err)
+		}
+
+		err := tl.UpdateTask("1", "", []string{"detail\r\ninjection"}, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for detail containing \\r\\n, got nil")
+		}
+	})
+
 	t.Run("UpdateTask rejects references with newline", func(t *testing.T) {
 		tl := &TaskList{Title: "Test"}
-		tl.AddTask("", "Valid task", "")
+		if _, err := tl.AddTask("", "Valid task", ""); err != nil {
+			t.Fatalf("test setup failed: %v", err)
+		}
 
 		err := tl.UpdateTask("1", "", nil, []string{"ref\ninjection"}, nil)
 		if err == nil {
@@ -1599,9 +1625,23 @@ func TestEmbeddedNewlinesRejected(t *testing.T) {
 		}
 	})
 
+	t.Run("UpdateTask rejects references with carriage return", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		if _, err := tl.AddTask("", "Valid task", ""); err != nil {
+			t.Fatalf("test setup failed: %v", err)
+		}
+
+		err := tl.UpdateTask("1", "", nil, []string{"ref\rinjection"}, nil)
+		if err == nil {
+			t.Fatal("expected error for reference containing \\r, got nil")
+		}
+	})
+
 	t.Run("UpdateTask rejects details with carriage return", func(t *testing.T) {
 		tl := &TaskList{Title: "Test"}
-		tl.AddTask("", "Valid task", "")
+		if _, err := tl.AddTask("", "Valid task", ""); err != nil {
+			t.Fatalf("test setup failed: %v", err)
+		}
 
 		err := tl.UpdateTask("1", "", []string{"detail\rinjection"}, nil, nil)
 		if err == nil {

--- a/internal/task/operations_test.go
+++ b/internal/task/operations_test.go
@@ -1540,3 +1540,93 @@ func TestTitleLengthValidation(t *testing.T) {
 		}
 	})
 }
+
+// TestEmbeddedNewlinesRejected verifies that embedded newlines (\n, \r)
+// are rejected in titles, details, and references to prevent markdown corruption.
+// Regression test for T-781.
+func TestEmbeddedNewlinesRejected(t *testing.T) {
+	t.Run("AddTask rejects title with newline", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTask("", "line1\nline2", "")
+		if err == nil {
+			t.Fatal("expected error for title containing \\n, got nil")
+		}
+	})
+
+	t.Run("AddTask rejects title with carriage return", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTask("", "line1\rline2", "")
+		if err == nil {
+			t.Fatal("expected error for title containing \\r, got nil")
+		}
+	})
+
+	t.Run("AddTask rejects title with CRLF", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTask("", "line1\r\nline2", "")
+		if err == nil {
+			t.Fatal("expected error for title containing \\r\\n, got nil")
+		}
+	})
+
+	t.Run("UpdateTask rejects title with newline", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		tl.AddTask("", "Valid task", "")
+
+		err := tl.UpdateTask("1", "new\ntitle", nil, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for title containing \\n, got nil")
+		}
+	})
+
+	t.Run("UpdateTask rejects details with newline", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		tl.AddTask("", "Valid task", "")
+
+		err := tl.UpdateTask("1", "", []string{"detail\ninjection"}, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for detail containing \\n, got nil")
+		}
+	})
+
+	t.Run("UpdateTask rejects references with newline", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		tl.AddTask("", "Valid task", "")
+
+		err := tl.UpdateTask("1", "", nil, []string{"ref\ninjection"}, nil)
+		if err == nil {
+			t.Fatal("expected error for reference containing \\n, got nil")
+		}
+	})
+
+	t.Run("UpdateTask rejects details with carriage return", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		tl.AddTask("", "Valid task", "")
+
+		err := tl.UpdateTask("1", "", []string{"detail\rinjection"}, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for detail containing \\r, got nil")
+		}
+	})
+
+	t.Run("valid inputs still accepted", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTask("", "Normal title with spaces", "")
+		if err != nil {
+			t.Fatalf("valid title rejected: %v", err)
+		}
+
+		err = tl.UpdateTask("1", "Updated title", []string{"A valid detail"}, []string{"https://example.com"}, nil)
+		if err != nil {
+			t.Fatalf("valid update rejected: %v", err)
+		}
+	})
+
+	t.Run("tab characters still accepted in titles", func(t *testing.T) {
+		tl := &TaskList{Title: "Test"}
+		_, err := tl.AddTask("", "Title\twith\ttabs", "")
+		if err != nil {
+			t.Fatalf("title with tabs should be accepted: %v", err)
+		}
+	})
+}

--- a/specs/bugfixes/task-input-embedded-newlines/report.md
+++ b/specs/bugfixes/task-input-embedded-newlines/report.md
@@ -1,0 +1,76 @@
+# Bugfix Report: task-input-embedded-newlines
+
+**Date:** 2026-04-16
+**Status:** Fixed
+**Transit:** T-781
+
+## Description of the Issue
+
+The `containsNullByte` helper function in `internal/task/operations.go` explicitly allowed `\n` and `\r` characters through validation. Since `validateTaskInput`, `validateDetails`, and `validateReferences` all relied on this helper, embedded newlines could be injected into task titles, details, and references. When rendered to markdown, these newlines break line structure, corrupting the task file.
+
+**Reproduction steps:**
+1. Call `AddTask` with a title containing `\n` (e.g., `"line1\nline2"`)
+2. Render the task list to markdown
+3. Observe the title splits across multiple lines, breaking the markdown task format
+
+**Impact:** Malformed markdown files could be generated from validated input, leading to data corruption on re-parse.
+
+## Investigation Summary
+
+- **Symptoms examined:** Newlines in titles/details/references pass validation but break markdown rendering
+- **Code inspected:** `internal/task/operations.go` — `containsNullByte`, `validateTaskInput`, `validateDetails`, `validateReferences`, `validateOwner`
+- **Hypotheses tested:** `validateOwner` already correctly rejects `\n`/`\r`, confirming the inconsistency is in the shared helper
+
+## Discovered Root Cause
+
+`containsNullByte` (line 440) had an allowlist for `\t`, `\n`, and `\r`:
+```go
+if r == 0 || (r < 32 && r != '\t' && r != '\n' && r != '\r') {
+```
+
+This meant newlines and carriage returns were treated as safe, but they break single-line markdown fields.
+
+**Defect type:** Missing validation
+
+**Why it occurred:** The helper was originally designed to catch null bytes and "dangerous" control characters, but `\n`/`\r` were considered benign whitespace rather than markdown-structure-breaking characters.
+
+**Contributing factors:** `validateOwner` was implemented separately with its own stricter check, so the inconsistency went unnoticed.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/operations.go:440` — Removed `\n` and `\r` from the allowlist in `containsNullByte`, so only `\t` is permitted among control characters
+
+**Approach rationale:** Single-point fix in the shared helper ensures all callers (`validateTaskInput`, `validateDetails`, `validateReferences`, and path validation) consistently reject embedded newlines. This aligns with `validateOwner`'s existing behaviour.
+
+**Alternatives considered:**
+- Add separate newline checks in each validator — rejected because it duplicates logic and risks future validators forgetting the check
+
+## Regression Test
+
+**Test file:** `internal/task/operations_test.go`
+**Test name:** `TestEmbeddedNewlinesRejected`
+
+**What it verifies:** `\n`, `\r`, and `\r\n` are rejected in titles (AddTask/UpdateTask), details, and references. Also verifies tabs and normal text are still accepted.
+
+**Run command:** `go test -run TestEmbeddedNewlinesRejected -v ./internal/task/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/operations.go` | Remove `\n`/`\r` from `containsNullByte` allowlist |
+| `internal/task/operations_test.go` | Add `TestEmbeddedNewlinesRejected` regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Code formatted with `make fmt`
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Validation helpers should default to rejecting control characters and explicitly allowlist only what's needed
+- Any new field validators should use the shared helper rather than implementing their own checks


### PR DESCRIPTION
## Bug

Task input validation allowed embedded `\n` and `\r` characters in titles, details, and references. When rendered to markdown, these newlines break line structure and corrupt the task file.

## Root Cause

`containsNullByte` in `internal/task/operations.go` explicitly allowed `\n` and `\r` through its control character check, while `validateOwner` correctly rejected them — an inconsistency.

## Fix

Removed `\n` and `\r` from the allowlist in `containsNullByte`, so only `\t` is permitted among control characters. This single-point fix ensures all callers consistently reject embedded newlines.

## Testing

- 9 regression tests in `TestEmbeddedNewlinesRejected` covering `\n`, `\r`, `\r\n` across AddTask/UpdateTask for titles, details, and references
- Full test suite passes

See `specs/bugfixes/task-input-embedded-newlines/report.md` for the full bugfix report.