### PR TITLE
Fix T-748: Renumber preserves all phase markers in multi-phase files

### DIFF
--- a/cmd/integration_renumber_test.go
+++ b/cmd/integration_renumber_test.go
@@ -229,12 +229,10 @@ func testRenumberWithPhases(t *testing.T, tempDir string) {
 		t.Fatalf("failed to parse renumbered file: %v", err)
 	}
 
-	// Verify at least one phase marker is preserved
-	// Note: There is a known issue with multiple phase markers not being correctly preserved
-	// during renumbering. This should be investigated and fixed separately.
-	if len(phaseMarkers) < 1 {
+	// Verify all phase markers are preserved (T-748: must be strict, not warning-only)
+	if len(phaseMarkers) != 2 {
 		t.Logf("Phase markers found: %+v", phaseMarkers)
-		t.Fatalf("expected at least 1 phase marker, got %d", len(phaseMarkers))
+		t.Fatalf("expected exactly 2 phase markers, got %d", len(phaseMarkers))
 	}
 
 	// Verify first phase marker
@@ -245,16 +243,12 @@ func testRenumberWithPhases(t *testing.T, tempDir string) {
 		t.Errorf("expected first phase after task 1, got after task %s", phaseMarkers[0].AfterTaskID)
 	}
 
-	// If we have a second phase marker, verify it
-	if len(phaseMarkers) >= 2 {
-		if phaseMarkers[1].Name != "Phase 2: Testing" {
-			t.Errorf("expected phase name 'Phase 2: Testing', got %s", phaseMarkers[1].Name)
-		}
-		if phaseMarkers[1].AfterTaskID != "3" {
-			t.Errorf("expected second phase after task 3, got after task %s", phaseMarkers[1].AfterTaskID)
-		}
-	} else {
-		t.Logf("WARNING: Second phase marker was not preserved (known issue)")
+	// Verify second phase marker
+	if phaseMarkers[1].Name != "Phase 2: Testing" {
+		t.Errorf("expected phase name 'Phase 2: Testing', got %s", phaseMarkers[1].Name)
+	}
+	if phaseMarkers[1].AfterTaskID != "3" {
+		t.Errorf("expected second phase after task 3, got after task %s", phaseMarkers[1].AfterTaskID)
 	}
 
 	// Verify tasks within phases are renumbered correctly
@@ -302,7 +296,7 @@ func testRenumberWithPhases(t *testing.T, tempDir string) {
 		t.Error("Phase 1 marker not found in file")
 	}
 	if phase2Line == -1 {
-		t.Logf("WARNING: Phase 2 marker not found in file (expected due to known issue)")
+		t.Error("Phase 2 marker not found in file")
 	}
 
 	// Verify phases are in correct positions (after specific tasks)

--- a/cmd/renumber.go
+++ b/cmd/renumber.go
@@ -278,13 +278,14 @@ func convertPhasePositionsToMarkers(positions []phasePosition, tl *task.TaskList
 	for _, pos := range positions {
 		marker := task.PhaseMarker{Name: pos.Name}
 
-		if pos.AfterPosition == -1 {
+		switch {
+		case pos.AfterPosition == -1:
 			// Phase at the beginning
 			marker.AfterTaskID = ""
-		} else if pos.AfterPosition < len(tl.Tasks) {
+		case pos.AfterPosition < len(tl.Tasks):
 			// Use the new ID of the task at this position
 			marker.AfterTaskID = tl.Tasks[pos.AfterPosition].ID
-		} else if len(tl.Tasks) > 0 {
+		case len(tl.Tasks) > 0:
 			// Position exceeds task count; anchor to the last task so the
 			// marker is preserved rather than silently dropped.
 			marker.AfterTaskID = tl.Tasks[len(tl.Tasks)-1].ID

--- a/cmd/renumber.go
+++ b/cmd/renumber.go
@@ -213,9 +213,15 @@ type phasePosition struct {
 // extractTaskIDOrder extracts root-level task IDs in the order they appear in the file.
 // This is needed because the parser automatically renumbers tasks, but phase markers
 // reference the original IDs from the file.
+// Front matter is stripped first so that the extracted IDs align with what
+// ExtractPhaseMarkers sees (it also strips front matter).
 func extractTaskIDOrder(content string) []string {
 	var taskIDs []string
 	lines := strings.Split(content, "\n")
+
+	// Strip front matter to stay consistent with ExtractPhaseMarkers,
+	// which also strips front matter before scanning for task IDs.
+	lines = task.StripFrontMatterLines(lines)
 
 	taskLinePattern := regexp.MustCompile(`^- \[[ \-xX]\] (\d+(?:\.\d+)*)\. `)
 
@@ -267,19 +273,25 @@ func convertPhaseMarkersToPositions(markers []task.PhaseMarker, fileTaskIDOrder 
 // convertPhasePositionsToMarkers converts position-based phase data back to
 // ID-based phase markers using the renumbered task IDs.
 func convertPhasePositionsToMarkers(positions []phasePosition, tl *task.TaskList) []task.PhaseMarker {
-	markers := make([]task.PhaseMarker, len(positions))
+	markers := make([]task.PhaseMarker, 0, len(positions))
 
-	for i, pos := range positions {
-		markers[i].Name = pos.Name
+	for _, pos := range positions {
+		marker := task.PhaseMarker{Name: pos.Name}
 
 		if pos.AfterPosition == -1 {
 			// Phase at the beginning
-			markers[i].AfterTaskID = ""
+			marker.AfterTaskID = ""
 		} else if pos.AfterPosition < len(tl.Tasks) {
 			// Use the new ID of the task at this position
-			markers[i].AfterTaskID = tl.Tasks[pos.AfterPosition].ID
+			marker.AfterTaskID = tl.Tasks[pos.AfterPosition].ID
+		} else if len(tl.Tasks) > 0 {
+			// Position exceeds task count; anchor to the last task so the
+			// marker is preserved rather than silently dropped.
+			marker.AfterTaskID = tl.Tasks[len(tl.Tasks)-1].ID
 		}
-		// If position is out of bounds, leave AfterTaskID empty (shouldn't happen)
+		// If there are no tasks at all, AfterTaskID stays empty.
+
+		markers = append(markers, marker)
 	}
 
 	return markers

--- a/cmd/renumber_test.go
+++ b/cmd/renumber_test.go
@@ -511,6 +511,16 @@ func TestExtractTaskIDOrder(t *testing.T) {
 - [ ] 2. Second`,
 			expected: []string{"1", "2"},
 		},
+		"with front matter": {
+			content: `---
+references:
+  - requirements.md
+---
+# Test
+- [ ] 1. First
+- [ ] 2. Second`,
+			expected: []string{"1", "2"},
+		},
 	}
 
 	for name, tc := range tests {
@@ -738,6 +748,232 @@ func TestRenumberWithPhases(t *testing.T) {
 	}
 	if phaseMarkers[1].AfterTaskID != "2" {
 		t.Errorf("Expected AfterTaskID '2', got '%s'", phaseMarkers[1].AfterTaskID)
+	}
+}
+
+// TestRenumberPreservesAllPhaseMarkers is a regression test for T-748:
+// renumbering must preserve all phase markers in multi-phase files with
+// non-sequential task IDs.
+func TestRenumberPreservesAllPhaseMarkers(t *testing.T) {
+	tempDir := filepath.Join(".", "test-tmp-renumber-all-phases")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := map[string]struct {
+		content            string
+		expectedPhaseCount int
+		expectedPhases     []task.PhaseMarker
+		expectedTaskIDs    []string
+	}{
+		"two phases with gaps": {
+			content: `# Test
+
+- [ ] 1. First task
+
+## Phase 1: Development
+
+- [ ] 5. Task in phase
+  - [ ] 5.1. Subtask
+- [ ] 8. Another task
+
+## Phase 2: Testing
+
+- [ ] 10. Testing task
+`,
+			expectedPhaseCount: 2,
+			expectedPhases: []task.PhaseMarker{
+				{Name: "Phase 1: Development", AfterTaskID: "1"},
+				{Name: "Phase 2: Testing", AfterTaskID: "3"},
+			},
+			expectedTaskIDs: []string{"1", "2", "3", "4"},
+		},
+		"three phases with gaps": {
+			content: `# Test
+
+- [ ] 1. Task A
+
+## Phase 1: Dev
+
+- [ ] 5. Task B
+- [ ] 8. Task C
+
+## Phase 2: Test
+
+- [ ] 12. Task D
+
+## Phase 3: Deploy
+
+- [ ] 20. Task E
+`,
+			expectedPhaseCount: 3,
+			expectedPhases: []task.PhaseMarker{
+				{Name: "Phase 1: Dev", AfterTaskID: "1"},
+				{Name: "Phase 2: Test", AfterTaskID: "3"},
+				{Name: "Phase 3: Deploy", AfterTaskID: "4"},
+			},
+			expectedTaskIDs: []string{"1", "2", "3", "4", "5"},
+		},
+		"phase before all tasks": {
+			content: `# Test
+
+## Phase 0: Setup
+
+- [ ] 3. Task A
+- [ ] 7. Task B
+
+## Phase 1: Work
+
+- [ ] 12. Task C
+`,
+			expectedPhaseCount: 2,
+			expectedPhases: []task.PhaseMarker{
+				{Name: "Phase 0: Setup", AfterTaskID: ""},
+				{Name: "Phase 1: Work", AfterTaskID: "2"},
+			},
+			expectedTaskIDs: []string{"1", "2", "3"},
+		},
+		"consecutive phases no tasks between": {
+			content: `# Test
+
+- [ ] 1. Task A
+
+## Phase 1: Dev
+
+- [ ] 5. Task B
+
+## Phase 2: Empty
+
+## Phase 3: Deploy
+
+- [ ] 10. Task C
+`,
+			expectedPhaseCount: 3,
+			expectedPhases: []task.PhaseMarker{
+				{Name: "Phase 1: Dev", AfterTaskID: "1"},
+				{Name: "Phase 2: Empty", AfterTaskID: "2"},
+				{Name: "Phase 3: Deploy", AfterTaskID: "2"},
+			},
+			expectedTaskIDs: []string{"1", "2", "3"},
+		},
+		"idempotent renumber": {
+			// Already-sequential IDs should remain unchanged after renumber
+			content: `# Test
+
+- [ ] 1. Task A
+
+## Phase 1: Dev
+
+- [ ] 2. Task B
+
+## Phase 2: Test
+
+- [ ] 3. Task C
+`,
+			expectedPhaseCount: 2,
+			expectedPhases: []task.PhaseMarker{
+				{Name: "Phase 1: Dev", AfterTaskID: "1"},
+				{Name: "Phase 2: Test", AfterTaskID: "2"},
+			},
+			expectedTaskIDs: []string{"1", "2", "3"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			testFile := filepath.Join(tempDir, name+".md")
+			if err := os.WriteFile(testFile, []byte(tc.content), 0644); err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+
+			// Count phase markers before renumber
+			beforeTL, beforeMarkers, err := task.ParseFileWithPhases(testFile)
+			if err != nil {
+				t.Fatalf("Failed to parse before renumber: %v", err)
+			}
+			_ = beforeTL
+
+			cmd := &cobra.Command{}
+			if err := runRenumber(cmd, []string{testFile}); err != nil {
+				t.Fatalf("Renumber failed: %v", err)
+			}
+
+			// Parse after renumber
+			afterTL, afterMarkers, err := task.ParseFileWithPhases(testFile)
+			if err != nil {
+				t.Fatalf("Failed to parse after renumber: %v", err)
+			}
+
+			// Phase marker count must be preserved
+			if len(afterMarkers) != tc.expectedPhaseCount {
+				t.Logf("Before markers: %+v", beforeMarkers)
+				t.Logf("After markers:  %+v", afterMarkers)
+				t.Fatalf("Expected %d phase markers, got %d", tc.expectedPhaseCount, len(afterMarkers))
+			}
+
+			// Verify each phase marker
+			for i, expected := range tc.expectedPhases {
+				if afterMarkers[i].Name != expected.Name {
+					t.Errorf("Phase %d: expected name %q, got %q", i, expected.Name, afterMarkers[i].Name)
+				}
+				if afterMarkers[i].AfterTaskID != expected.AfterTaskID {
+					t.Errorf("Phase %d: expected AfterTaskID %q, got %q", i, expected.AfterTaskID, afterMarkers[i].AfterTaskID)
+				}
+			}
+
+			// Verify task IDs are sequential
+			for i, expectedID := range tc.expectedTaskIDs {
+				if i >= len(afterTL.Tasks) {
+					t.Fatalf("Expected task %d with ID %s, but only %d root tasks exist", i, expectedID, len(afterTL.Tasks))
+				}
+				if afterTL.Tasks[i].ID != expectedID {
+					t.Errorf("Task %d: expected ID %s, got %s", i, expectedID, afterTL.Tasks[i].ID)
+				}
+			}
+
+			// Verify file content contains all phase headers
+			fileContent, err := os.ReadFile(testFile)
+			if err != nil {
+				t.Fatalf("Failed to read file: %v", err)
+			}
+			for _, expected := range tc.expectedPhases {
+				if !strings.Contains(string(fileContent), "## "+expected.Name) {
+					t.Errorf("Phase header %q not found in file content", expected.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestConvertPhasePositionsToMarkersOutOfBounds verifies that out-of-bounds
+// positions are handled gracefully (anchored to last task, not silently dropped).
+func TestConvertPhasePositionsToMarkersOutOfBounds(t *testing.T) {
+	tl := &task.TaskList{
+		Tasks: []task.Task{
+			{ID: "1", Title: "Task A"},
+			{ID: "2", Title: "Task B"},
+		},
+	}
+
+	positions := []phasePosition{
+		{Name: "Phase 1", AfterPosition: 0},
+		{Name: "Phase 2", AfterPosition: 5}, // out of bounds
+	}
+
+	markers := convertPhasePositionsToMarkers(positions, tl)
+
+	if len(markers) != 2 {
+		t.Fatalf("Expected 2 markers, got %d", len(markers))
+	}
+
+	if markers[0].AfterTaskID != "1" {
+		t.Errorf("Marker 0: expected AfterTaskID '1', got %q", markers[0].AfterTaskID)
+	}
+
+	// Out-of-bounds position should anchor to last task, not be empty
+	if markers[1].AfterTaskID != "2" {
+		t.Errorf("Marker 1: expected AfterTaskID '2' (last task), got %q", markers[1].AfterTaskID)
 	}
 }
 

--- a/cmd/renumber_test.go
+++ b/cmd/renumber_test.go
@@ -888,11 +888,10 @@ func TestRenumberPreservesAllPhaseMarkers(t *testing.T) {
 			}
 
 			// Count phase markers before renumber
-			beforeTL, beforeMarkers, err := task.ParseFileWithPhases(testFile)
+			_, beforeMarkers, err := task.ParseFileWithPhases(testFile)
 			if err != nil {
 				t.Fatalf("Failed to parse before renumber: %v", err)
 			}
-			_ = beforeTL
 
 			cmd := &cobra.Command{}
 			if err := runRenumber(cmd, []string{testFile}); err != nil {

--- a/specs/bugfixes/renumber-drops-later-phase-markers/report.md
+++ b/specs/bugfixes/renumber-drops-later-phase-markers/report.md
@@ -1,0 +1,114 @@
+# Bugfix Report: renumber-drops-later-phase-markers
+
+**Date:** 2025-07-16
+**Status:** Fixed
+**Ticket:** T-748
+
+## Description of the Issue
+
+The `rune renumber` command could silently drop phase markers (H2 headers) in
+multi-phase files. In the worst case only the first phase header survived a
+renumber; all subsequent phases were lost.
+
+**Reproduction steps:**
+1. Create a task file with 2+ phase headers and non-sequential task IDs.
+2. Run `rune renumber <file>`.
+3. Observe that later phase headers may be missing from the output.
+
+**Impact:** Medium — data loss of phase structure in task files after
+renumbering. The integration test logged this as a "known issue" with a
+warning instead of failing.
+
+## Investigation Summary
+
+- **Symptoms examined:** Integration test
+  `testRenumberWithPhases` used weak assertions (`len >= 1` instead of `== 2`)
+  with a logged warning when the second phase marker was absent.
+- **Code inspected:** `cmd/renumber.go` (conversion functions),
+  `internal/task/render.go` (`RenderMarkdownWithPhases`),
+  `internal/task/parse.go` (`ExtractPhaseMarkers`).
+- **Hypotheses tested:**
+  1. Position-based conversion drops out-of-bounds phases → **confirmed latent bug**.
+  2. `extractTaskIDOrder` reads front matter and produces misaligned positions → **confirmed latent bug**.
+  3. `RenderMarkdownWithPhases` silently skips markers with empty `AfterTaskID` in non-initial positions → **confirmed downstream effect**.
+
+## Discovered Root Cause
+
+Two latent defects in `cmd/renumber.go`:
+
+1. **`extractTaskIDOrder` did not strip YAML front matter.** `ExtractPhaseMarkers`
+   (used by `ParseFileWithPhases`) strips front matter before scanning, so the two
+   functions could disagree on the set of task IDs. If front matter contained
+   text matching the task-line regex, `extractTaskIDOrder` would produce extra
+   entries, shifting all subsequent position mappings.
+
+2. **`convertPhasePositionsToMarkers` silently dropped markers when position was
+   out of bounds.** If a position exceeded `len(tl.Tasks)`, the marker's
+   `AfterTaskID` was left as `""`. Markers with empty `AfterTaskID` in
+   non-initial positions are never emitted by `RenderMarkdownWithPhases`,
+   effectively deleting them from the file.
+
+**Defect type:** Logic error + missing error recovery.
+
+**Why it occurred:** The renumber pipeline was added in one commit and
+subsequent changes (front matter support, phase rendering) introduced subtle
+misalignments that the weak integration test did not catch.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/renumber.go` — `extractTaskIDOrder` now calls `task.StripFrontMatterLines`
+  before scanning, aligning it with `ExtractPhaseMarkers`.
+- `cmd/renumber.go` — `convertPhasePositionsToMarkers` now anchors out-of-bounds
+  positions to the last task instead of silently producing an empty `AfterTaskID`.
+- `cmd/integration_renumber_test.go` — Replaced weak `len >= 1` + warning
+  assertions with strict `len == 2` checks for both phase markers.
+- `cmd/renumber_test.go` — Added `TestRenumberPreservesAllPhaseMarkers` covering
+  five scenarios (2-phase gaps, 3-phase gaps, phase-before-tasks, consecutive
+  phases, idempotent renumber). Added `TestConvertPhasePositionsToMarkersOutOfBounds`
+  for the out-of-bounds recovery. Added front-matter test case to
+  `TestExtractTaskIDOrder`.
+
+**Approach rationale:** Fix the root causes (front matter mismatch, silent
+drop) and add comprehensive regression tests.
+
+## Regression Test
+
+**Test file:** `cmd/renumber_test.go`
+**Test names:**
+- `TestRenumberPreservesAllPhaseMarkers` — exercises 5 multi-phase scenarios
+- `TestConvertPhasePositionsToMarkersOutOfBounds` — validates recovery from bad positions
+- `TestExtractTaskIDOrder/with_front_matter` — validates front-matter stripping
+
+**What it verifies:** After renumber, `ParseFileWithPhases` returns the same
+number of phase markers as before, each with the correct name and updated
+`AfterTaskID`.
+
+**Run command:** `go test -run "TestRenumberPreservesAllPhaseMarkers|TestConvertPhasePositionsToMarkersOutOfBounds|TestExtractTaskIDOrder" -v ./cmd`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/renumber.go` | Strip front matter in `extractTaskIDOrder`; recover gracefully in `convertPhasePositionsToMarkers` |
+| `cmd/renumber_test.go` | Add regression tests for multi-phase renumbering and out-of-bounds positions |
+| `cmd/integration_renumber_test.go` | Replace weak assertions with strict phase-marker count checks |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes (`make test-all`)
+- [x] Code formatted (`make fmt`)
+
+## Prevention
+
+- When two functions scan the same content, ensure they apply the same
+  pre-processing (e.g., front matter stripping).
+- Avoid silently discarding data on unexpected conditions; anchor to a safe
+  default or return an error.
+- Use strict assertions in tests; "known issue" warnings mask real regressions.
+
+## Related
+
+- T-748: Renumber can drop later phase markers in multi-phase files


### PR DESCRIPTION
## Bug

`rune renumber` could silently drop later phase markers (H2 headers) in multi-phase files. The integration test logged this as a "known issue" with a warning instead of failing.

## Root Cause

Two latent defects in `cmd/renumber.go`:

1. **`extractTaskIDOrder` didn't strip YAML front matter**, while `ExtractPhaseMarkers` did — causing position misalignment.
2. **`convertPhasePositionsToMarkers` silently dropped markers** when position was out of bounds (left `AfterTaskID` empty, which `RenderMarkdownWithPhases` never emits in non-initial positions).

## Fix

- `extractTaskIDOrder` now strips front matter before scanning
- `convertPhasePositionsToMarkers` anchors out-of-bounds positions to the last task
- Integration test upgraded from warning-only to strict assertions
- Added comprehensive regression tests (5 multi-phase scenarios + edge cases)

## Testing

- All new tests pass
- Full test suite passes (`make test-all`)

See `specs/bugfixes/renumber-drops-later-phase-markers/report.md` for full investigation.