### PR TITLE
Fix T-787: Batch add to earlier phase misplaces later phase markers

### DIFF
--- a/internal/task/batch.go
+++ b/internal/task/batch.go
@@ -968,14 +968,14 @@ func addTaskWithPhaseMarkers(tl *TaskList, op Operation, phaseMarkers *[]PhaseMa
 		// Find the next phase marker after our target phase
 		for i, marker := range *phaseMarkers {
 			if marker.Name == op.Phase {
-				// Look for the next phase marker
-				if i+1 < len(*phaseMarkers) {
-					nextMarker := &(*phaseMarkers)[i+1]
-					// Update the next phase to start after the newly inserted task
-					// (which is now the last task in the current phase)
-					if insertPosition < len(tl.Tasks) {
-						nextMarker.AfterTaskID = tl.Tasks[insertPosition].ID
-					}
+				// Update the immediate next marker to point to the newly inserted task
+				if i+1 < len(*phaseMarkers) && insertPosition < len(tl.Tasks) {
+					(*phaseMarkers)[i+1].AfterTaskID = tl.Tasks[insertPosition].ID
+				}
+				// Adjust all markers beyond the next one for the shifted task numbering
+				if i+2 < len(*phaseMarkers) {
+					remaining := (*phaseMarkers)[i+2:]
+					adjustPhaseMarkersForInsertion(insertPosition, &remaining)
 				}
 				break
 			}

--- a/internal/task/batch_operations_test.go
+++ b/internal/task/batch_operations_test.go
@@ -1366,6 +1366,9 @@ func TestBatchAddToEarlierPhaseMisplacesLaterMarkers(t *testing.T) {
 	// Also verify task ordering: A1, A2, B1, C1
 	a1Idx := strings.Index(result, "A1")
 	a2Idx := strings.Index(result, "A2")
+	if a2Idx < 0 {
+		t.Fatalf("A2 task missing from output:\n%s", result)
+	}
 	if a1Idx > a2Idx || a2Idx > b1Idx || b1Idx > c1Idx {
 		t.Errorf("Tasks should be ordered A1, A2, B1, C1, got:\n%s", result)
 	}

--- a/internal/task/batch_operations_test.go
+++ b/internal/task/batch_operations_test.go
@@ -1291,3 +1291,82 @@ func TestValidateOperation_AddPhase(t *testing.T) {
 		})
 	}
 }
+
+// TestBatchAddToEarlierPhaseMisplacesLaterMarkers reproduces the bug where
+// batch-adding a top-level task to an earlier phase only updates the immediate
+// next phase marker, leaving later phase markers with stale AfterTaskIDs.
+// This causes later phase headers to render before the wrong tasks.
+func TestBatchAddToEarlierPhaseMisplacesLaterMarkers(t *testing.T) {
+	content := `# Tasks
+
+## A
+
+- [ ] 1. A1
+
+## B
+
+- [ ] 2. B1
+
+## C
+
+- [ ] 3. C1`
+
+	tempFile := "test_batch_add_earlier_phase_later_markers.md"
+	if err := os.WriteFile(tempFile, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+	defer os.Remove(tempFile)
+
+	tl, phaseMarkers, err := ParseFileWithPhases(tempFile)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	ops := []Operation{
+		{
+			Type:  "add",
+			Title: "A2",
+			Phase: "A",
+		},
+	}
+
+	response, err := tl.ExecuteBatchWithPhases(ops, false, phaseMarkers, tempFile)
+	if err != nil {
+		t.Fatalf("ExecuteBatchWithPhases failed: %v", err)
+	}
+	if !response.Success {
+		t.Fatalf("Expected success, got errors: %v", response.Errors)
+	}
+
+	// Re-read the written file to verify correct rendering
+	got, err := os.ReadFile(tempFile)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	result := string(got)
+
+	// Phase B must appear before B1, and phase C must appear before C1.
+	bIdx := strings.Index(result, "## B")
+	cIdx := strings.Index(result, "## C")
+	b1Idx := strings.Index(result, "B1")
+	c1Idx := strings.Index(result, "C1")
+
+	if bIdx < 0 || cIdx < 0 || b1Idx < 0 || c1Idx < 0 {
+		t.Fatalf("Missing expected content in output:\n%s", result)
+	}
+
+	if bIdx > b1Idx {
+		t.Errorf("Phase B header should appear before B1 task, got:\n%s", result)
+	}
+	if cIdx > c1Idx {
+		t.Errorf("Phase C header should appear before C1 task, got:\n%s", result)
+	}
+
+	// Also verify task ordering: A1, A2, B1, C1
+	a1Idx := strings.Index(result, "A1")
+	a2Idx := strings.Index(result, "A2")
+	if a1Idx > a2Idx || a2Idx > b1Idx || b1Idx > c1Idx {
+		t.Errorf("Tasks should be ordered A1, A2, B1, C1, got:\n%s", result)
+	}
+}

--- a/specs/bugfixes/batch-add-earlier-phase-misplaces-markers/report.md
+++ b/specs/bugfixes/batch-add-earlier-phase-misplaces-markers/report.md
@@ -1,0 +1,74 @@
+# Bugfix Report: Batch Add to Earlier Phase Misplaces Later Phase Markers
+
+**Date:** 2026-04-16
+**Status:** Fixed
+
+## Description of the Issue
+
+When `rune batch` adds a top-level task to an earlier phase in a file with three or more phases, `addTaskWithPhaseMarkers` updates only the immediate next phase marker after insertion. Later markers keep their old `AfterTaskID` even though top-level tasks were renumbered, so rendering moves later phase headers before the wrong tasks.
+
+**Reproduction steps:**
+1. Create a task file with three phases (A, B, C) each containing one task
+2. Run batch JSON adding a new task to phase A
+3. Observe that phases B and C are misplaced in the output — phase C header appears before B1 instead of before C1
+
+**Impact:** Any batch add to an earlier phase in a multi-phase file corrupts the phase layout of all phases beyond the immediately next one.
+
+## Investigation Summary
+
+- **Symptoms examined:** Phase headers rendered before incorrect tasks after batch add
+- **Code inspected:** `internal/task/batch.go` (`addTaskWithPhaseMarkers`), `internal/task/operations.go` (`AddTaskToPhase`, `adjustPhaseMarkersForInsertion`)
+- **Hypotheses tested:** Compared the phase marker update logic in both code paths
+
+## Discovered Root Cause
+
+In `internal/task/batch.go`, the `addTaskWithPhaseMarkers` function only updates the immediate next phase marker (i+1) after inserting a task. It does not adjust the `AfterTaskID` of markers beyond i+1, even though task renumbering shifts all subsequent task IDs.
+
+**Defect type:** Missing logic — incomplete port of phase marker adjustment
+
+**Why it occurred:** The standalone `AddTaskToPhase` in `operations.go` was later enhanced with `adjustPhaseMarkersForInsertion` for markers at i+2 and beyond, but the parallel batch code path in `batch.go` was not updated to match.
+
+**Contributing factors:** Two separate code paths performing the same logical operation (phase-aware task insertion) without shared implementation.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/batch.go:967-983` — Added `adjustPhaseMarkersForInsertion` call for markers at index i+2 and beyond, matching the logic in `AddTaskToPhase`
+
+**Approach rationale:** The fix mirrors exactly what `AddTaskToPhase` already does correctly, ensuring both code paths behave identically.
+
+**Alternatives considered:**
+- Refactor both paths to share a single implementation — better long-term but higher risk for this fix
+
+## Regression Test
+
+**Test file:** `internal/task/batch_operations_test.go`
+**Test name:** `TestBatchAddToEarlierPhaseMisplacesLaterMarkers`
+
+**What it verifies:** Adding a task to phase A in a 3-phase file (A, B, C) preserves correct phase header placement for phases B and C.
+
+**Run command:** `go test -run TestBatchAddToEarlierPhaseMisplacesLaterMarkers -v ./internal/task/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/batch.go` | Added `adjustPhaseMarkersForInsertion` for markers beyond the immediate next |
+| `internal/task/batch_operations_test.go` | Added regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Build succeeds
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Consider extracting the shared phase-marker-update logic into a single helper function used by both `AddTaskToPhase` and `addTaskWithPhaseMarkers`
+- When adding phase marker adjustment logic, always test with 3+ phases to catch off-by-one marker updates
+
+## Related
+
+- Transit ticket: T-787


### PR DESCRIPTION
## Bug

When `rune batch` adds a top-level task to an earlier phase in a file with 3+ phases, `addTaskWithPhaseMarkers` only updated the immediate next phase marker. Later markers kept stale `AfterTaskID` values, causing phase headers to render before the wrong tasks.

## Root Cause

The batch path in `batch.go` was missing the `adjustPhaseMarkersForInsertion` call for markers at index i+2 onwards. The standalone `AddTaskToPhase` in `operations.go` already had this fix.

## Fix

Added the missing `adjustPhaseMarkersForInsertion` call to `addTaskWithPhaseMarkers`, matching the logic in `AddTaskToPhase`.

## Testing

- Added regression test `TestBatchAddToEarlierPhaseMisplacesLaterMarkers` with a 3-phase file
- All existing tests pass

See `specs/bugfixes/batch-add-earlier-phase-misplaces-markers/report.md` for full details.