### PR TITLE
Fix T-801: Remove Command Reports Wrong Title After Deleting Earlier Task

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -91,14 +91,16 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("task %s not found", taskID)
 	}
 
-	// Count children recursively for informational output
+	// Capture task info by value before any mutation, since RemoveTaskWithPhases
+	// renumbers the slice and the pointer may refer to a different task afterward.
+	removedTitle := targetTask.Title
 	childCount := countTaskChildren(targetTask)
 
 	// Dry run mode - show what would be removed
 	if dryRun {
 		fmt.Printf("Would remove task from file: %s\n", filename)
 		fmt.Printf("Task ID: %s\n", taskID)
-		fmt.Printf("Title: %s\n", targetTask.Title)
+		fmt.Printf("Title: %s\n", removedTitle)
 		if childCount > 0 {
 			fmt.Printf("This task has %d subtask(s) that will also be removed\n", childCount)
 			fmt.Println("Subtasks to be removed:")
@@ -113,37 +115,37 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to remove task: %w", err)
 	}
 
-	// Format-aware output
+	// Format-aware output (uses captured values, not the now-stale pointer)
 	switch format {
 	case formatJSON:
 		return outputJSON(RemoveResponse{
 			Success:         true,
 			Message:         fmt.Sprintf("Removed task %s", taskID),
 			TaskID:          taskID,
-			Title:           targetTask.Title,
+			Title:           removedTitle,
 			ChildrenRemoved: childCount,
 		})
 	case formatMarkdown:
 		if childCount > 0 {
-			fmt.Printf("**Removed:** %s - %s (and %d subtasks)\n", taskID, targetTask.Title, childCount)
+			fmt.Printf("**Removed:** %s - %s (and %d subtasks)\n", taskID, removedTitle, childCount)
 		} else {
-			fmt.Printf("**Removed:** %s - %s\n", taskID, targetTask.Title)
+			fmt.Printf("**Removed:** %s - %s\n", taskID, removedTitle)
 		}
 		return nil
 	default: // table
 		if verbose {
 			fmt.Printf("Successfully removed task from file: %s\n", filename)
 			fmt.Printf("Removed task ID: %s\n", taskID)
-			fmt.Printf("Title: %s\n", targetTask.Title)
+			fmt.Printf("Title: %s\n", removedTitle)
 			if childCount > 0 {
 				fmt.Printf("Also removed %d subtask(s)\n", childCount)
 			}
 			fmt.Printf("Remaining tasks have been renumbered\n")
 		} else {
 			if childCount > 0 {
-				fmt.Printf("Removed task %s and %d subtask(s): %s\n", taskID, childCount, targetTask.Title)
+				fmt.Printf("Removed task %s and %d subtask(s): %s\n", taskID, childCount, removedTitle)
 			} else {
-				fmt.Printf("Removed task %s: %s\n", taskID, targetTask.Title)
+				fmt.Printf("Removed task %s: %s\n", taskID, removedTitle)
 			}
 		}
 		return nil

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -422,6 +422,7 @@ func TestRemoveReportsCorrectTitleAfterDeletion(t *testing.T) {
 		taskID        string
 		expectedTitle string
 		format        string
+		dryRun        bool
 	}{
 		"table format reports correct title when removing first task": {
 			taskID:        "1",
@@ -438,9 +439,15 @@ func TestRemoveReportsCorrectTitleAfterDeletion(t *testing.T) {
 			expectedTitle: "Blocker",
 			format:        "markdown",
 		},
+		"dry-run reports correct title when removing first task": {
+			taskID:        "1",
+			expectedTitle: "Blocker",
+			format:        "table",
+			dryRun:        true,
+		},
 	}
 
-	for name, tt := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			filename := filepath.Join(tempDir, "test-"+strings.ReplaceAll(name, " ", "-")+".md")
 
@@ -452,32 +459,40 @@ func TestRemoveReportsCorrectTitleAfterDeletion(t *testing.T) {
 				t.Fatalf("Failed to create test file: %v", err)
 			}
 
-			dryRun = false
+			oldDryRun := dryRun
+			dryRun = tc.dryRun
+			t.Cleanup(func() { dryRun = oldDryRun })
+
 			oldFormat := format
-			format = tt.format
-			defer func() { format = oldFormat }()
+			format = tc.format
+			t.Cleanup(func() { format = oldFormat })
 
 			// Capture stdout
 			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("os.Pipe: %v", err)
+			}
 			os.Stdout = w
 
 			cmd := &cobra.Command{}
-			args := []string{filename, tt.taskID}
-			err := runRemove(cmd, args)
+			args := []string{filename, tc.taskID}
+			runErr := runRemove(cmd, args)
 
 			w.Close()
 			os.Stdout = oldStdout
 			var buf bytes.Buffer
-			buf.ReadFrom(r)
+			if _, err := buf.ReadFrom(r); err != nil {
+				t.Fatalf("ReadFrom: %v", err)
+			}
 			output := buf.String()
 
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
+			if runErr != nil {
+				t.Fatalf("Unexpected error: %v", runErr)
 			}
 
-			if !strings.Contains(output, tt.expectedTitle) {
-				t.Errorf("Expected output to contain removed task title %q, got: %s", tt.expectedTitle, output)
+			if !strings.Contains(output, tc.expectedTitle) {
+				t.Errorf("Expected output to contain removed task title %q, got: %s", tc.expectedTitle, output)
 			}
 			if strings.Contains(output, "Dependent") {
 				t.Errorf("Output should NOT contain the shifted task title 'Dependent', got: %s", output)

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -408,6 +408,84 @@ func TestCountTaskChildren(t *testing.T) {
 	}
 }
 
+// TestRemoveReportsCorrectTitleAfterDeletion is a regression test for T-801.
+// When removing task 1, the command should print the title of the removed task,
+// not the title of the task that shifted into its position after renumbering.
+func TestRemoveReportsCorrectTitleAfterDeletion(t *testing.T) {
+	tempDir := filepath.Join(".", "test-tmp-remove-title-bug")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := map[string]struct {
+		taskID        string
+		expectedTitle string
+		format        string
+	}{
+		"table format reports correct title when removing first task": {
+			taskID:        "1",
+			expectedTitle: "Blocker",
+			format:        "table",
+		},
+		"json format reports correct title when removing first task": {
+			taskID:        "1",
+			expectedTitle: "Blocker",
+			format:        "json",
+		},
+		"markdown format reports correct title when removing first task": {
+			taskID:        "1",
+			expectedTitle: "Blocker",
+			format:        "markdown",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			filename := filepath.Join(tempDir, "test-"+strings.ReplaceAll(name, " ", "-")+".md")
+
+			// Create file with two tasks: "Blocker" at 1, "Dependent" at 2
+			tl := task.NewTaskList("Test Tasks")
+			tl.AddTask("", "Blocker", "")
+			tl.AddTask("", "Dependent", "")
+			if err := tl.WriteFile(filename); err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			dryRun = false
+			oldFormat := format
+			format = tt.format
+			defer func() { format = oldFormat }()
+
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			cmd := &cobra.Command{}
+			args := []string{filename, tt.taskID}
+			err := runRemove(cmd, args)
+
+			w.Close()
+			os.Stdout = oldStdout
+			var buf bytes.Buffer
+			buf.ReadFrom(r)
+			output := buf.String()
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if !strings.Contains(output, tt.expectedTitle) {
+				t.Errorf("Expected output to contain removed task title %q, got: %s", tt.expectedTitle, output)
+			}
+			if strings.Contains(output, "Dependent") {
+				t.Errorf("Output should NOT contain the shifted task title 'Dependent', got: %s", output)
+			}
+		})
+	}
+}
+
 func TestStatusToCheckbox(t *testing.T) {
 	tests := map[string]struct {
 		status   task.Status

--- a/specs/bugfixes/remove-reports-wrong-title/report.md
+++ b/specs/bugfixes/remove-reports-wrong-title/report.md
@@ -1,0 +1,72 @@
+# Bugfix Report: Remove Reports Wrong Title
+
+**Date:** 2026-04-16
+**Status:** Fixed
+**Ticket:** T-801
+
+## Description of the Issue
+
+After removing a task that is not the last in the list, the `rune remove` command prints the title of the task that shifted into the removed task's position, instead of the title of the task that was actually removed.
+
+**Reproduction steps:**
+1. Create a task file with task 1 titled `Blocker` and task 2 titled `Dependent`
+2. Run `rune remove <file> 1`
+3. Observe the command prints `Removed task 1: Dependent` instead of `Removed task 1: Blocker`
+
+**Impact:** Low severity — file mutation is correct, but user-facing output is misleading. Affects all output formats (table, JSON, markdown).
+
+## Investigation Summary
+
+- **Symptoms examined:** Output after remove shows wrong task title
+- **Code inspected:** `cmd/remove.go` — the `runRemove` function
+- **Hypotheses tested:** Pointer aliasing after slice mutation confirmed as root cause
+
+## Discovered Root Cause
+
+In `cmd/remove.go`, `targetTask := tl.FindTask(taskID)` returns a pointer into the `tl.Tasks` slice. After `tl.RemoveTaskWithPhases(taskID, content)` mutates and renumbers the slice, the pointer refers to whatever task shifted into that memory position — typically the next task in the original list.
+
+**Defect type:** Use-after-mutation (stale pointer into mutated slice)
+
+**Why it occurred:** The task info (title, child count) was read from the pointer after the slice was mutated, rather than being captured by value beforehand.
+
+**Contributing factors:** Go slices are reference types; removing an element and compacting the slice causes subsequent elements to shift, making any pre-existing pointers into the slice unreliable.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/remove.go:94-96` — Capture `removedTitle` and `childCount` as value copies before calling `RemoveTaskWithPhases`
+- `cmd/remove.go:117-151` — Replace all references to `targetTask.Title` with the captured `removedTitle` variable
+
+**Approach rationale:** Minimal, surgical fix — capture the needed values by value before the mutation. No changes to the task engine or data structures required.
+
+**Alternatives considered:**
+- Making `RemoveTaskWithPhases` return removed task info — rejected as unnecessarily invasive change to the API
+
+## Regression Test
+
+**Test file:** `cmd/remove_test.go`
+**Test name:** `TestRemoveReportsCorrectTitleAfterDeletion`
+
+**What it verifies:** When removing task 1 (titled "Blocker") from a file with task 2 (titled "Dependent"), the output contains "Blocker" and does not contain "Dependent". Tests all three output formats.
+
+**Run command:** `go test -run TestRemoveReportsCorrectTitleAfterDeletion -v ./cmd`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/remove.go` | Capture title/childCount by value before mutation |
+| `cmd/remove_test.go` | Add regression test for T-801 |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Code formatted (`make fmt`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When reading data from a struct pointer that will be mutated, capture needed fields by value before the mutation
+- Consider returning removed-item metadata from mutation methods to avoid the pattern entirely


### PR DESCRIPTION
## Bug

The `rune remove` command printed the wrong task title after deleting a task that wasn't last in the list. For example, removing task 1 ("Blocker") from a file with task 2 ("Dependent") would print `Removed task 1: Dependent`.

## Root Cause

`cmd/remove.go` used a pointer (`targetTask`) into the `tl.Tasks` slice to read the title *after* `RemoveTaskWithPhases` mutated and renumbered the slice. The pointer then referred to whichever task shifted into that position.

## Fix

Capture `removedTitle` and `childCount` by value before calling `RemoveTaskWithPhases`, then use those captured values in all output paths.

## Testing

- Added `TestRemoveReportsCorrectTitleAfterDeletion` covering table, JSON, and markdown formats
- All existing tests pass

See `specs/bugfixes/remove-reports-wrong-title/report.md` for the full bugfix report.