### PR TITLE
Fix T-812: Config Tests Write To Real Home Directory

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,6 @@ discovery:
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			resetConfigCache()
 			t.Cleanup(func() { resetConfigCache() })
 
 			// Isolate: work in a temp directory with a fake HOME
@@ -260,6 +259,7 @@ func TestLoadConfigFromSubdirectory(t *testing.T) {
 
 	// Create a temp directory simulating a repo root
 	tempDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
 	t.Cleanup(func() { resetConfigCache() })
 
 	// Create .rune.yml at the "repo root" with a distinctive template
@@ -305,6 +305,7 @@ discovery:
 func TestLoadConfigUncachedInvalidYAML(t *testing.T) {
 	resetConfigCache()
 	tempDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
 	t.Cleanup(func() { resetConfigCache() })
 
 	// Initialize git repo so getRepoRoot (which shells out to git rev-parse) works
@@ -338,6 +339,7 @@ func TestLoadConfigUncachedInvalidYAML(t *testing.T) {
 func TestLoadConfigUncachedUnknownFields(t *testing.T) {
 	resetConfigCache()
 	tempDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
 	t.Cleanup(func() { resetConfigCache() })
 
 	// Initialize git repo so getRepoRoot (which shells out to git rev-parse) works
@@ -436,6 +438,7 @@ discovery:
 func TestLoadConfigUncachedMissingFileStillDefaults(t *testing.T) {
 	resetConfigCache()
 	tempDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
 	t.Cleanup(func() { resetConfigCache() })
 
 	// Initialize git repo but do NOT create .rune.yml

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,47 +9,56 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	tests := map[string]struct {
-		setup       func(t *testing.T) string
-		cleanup     func(string)
+		writeConfig bool
+		content     string
 		wantEnabled bool
 		wantErr     bool
 	}{
 		"loads from current directory .rune.yml": {
-			setup: func(t *testing.T) string {
-				resetConfigCache() // Reset cache before test
-				content := `
+			writeConfig: true,
+			content: `
 discovery:
   enabled: true
   template: "tasks/{branch}.md"
-`
-				err := os.WriteFile(".rune.yml", []byte(content), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-				return ".rune.yml"
-			},
-			cleanup: func(path string) {
-				os.Remove(path)
-			},
+`,
 			wantEnabled: true,
 		},
 		"returns default config when no file exists": {
-			setup: func(t *testing.T) string {
-				resetConfigCache() // Reset cache before test
-				// Ensure no config files exist
-				os.Remove(".rune.yml")
-				return ""
-			},
-			cleanup:     func(string) {},
+			writeConfig: false,
 			wantEnabled: true,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			path := tc.setup(t)
-			if tc.cleanup != nil {
-				defer tc.cleanup(path)
+			resetConfigCache()
+
+			// Isolate: work in a temp directory with a fake HOME
+			tempDir := t.TempDir()
+			fakeHome := t.TempDir()
+			t.Setenv("HOME", fakeHome)
+
+			originalDir, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				os.Chdir(originalDir)
+				resetConfigCache()
+			})
+
+			// Init a git repo so getRepoRoot works
+			cmd := exec.Command("git", "-C", tempDir, "init")
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("git init failed: %v", err)
+			}
+
+			os.Chdir(tempDir)
+
+			if tc.writeConfig {
+				if err := os.WriteFile(filepath.Join(tempDir, ".rune.yml"), []byte(tc.content), 0644); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			cfg, err := LoadConfig()
@@ -165,13 +174,17 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestExpandHome(t *testing.T) {
+	// Use a fake HOME so the test is deterministic and never touches the real home
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
 	tests := map[string]struct {
 		input string
 		want  string
 	}{
 		"expands tilde": {
 			input: "~/config/file.yml",
-			want:  filepath.Join(os.Getenv("HOME"), "config/file.yml"),
+			want:  filepath.Join(fakeHome, "config/file.yml"),
 		},
 		"no tilde": {
 			input: "/absolute/path/file.yml",
@@ -185,58 +198,61 @@ func TestExpandHome(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Set HOME env var for consistent testing
-			home := os.Getenv("HOME")
-			if home == "" {
-				home, _ = os.UserHomeDir()
-			}
-
 			got := expandHome(tc.input)
-
-			// For tilde expansion, check that it starts with home dir
-			if tc.input[:2] == "~/" {
-				if !contains(got, home) {
-					t.Errorf("expandHome(%q) = %q, should contain home dir %q", tc.input, got, home)
-				}
-			} else {
-				if got != tc.want {
-					t.Errorf("expandHome(%q) = %q, want %q", tc.input, got, tc.want)
-				}
+			if got != tc.want {
+				t.Errorf("expandHome(%q) = %q, want %q", tc.input, got, tc.want)
 			}
 		})
 	}
 }
 
 func TestConfigPrecedence(t *testing.T) {
-	resetConfigCache() // Reset cache before test
+	resetConfigCache()
 
-	// Create config in current directory
+	// Isolate: use temp directories so we never touch the real home
+	tempDir := t.TempDir()
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(originalDir)
+		resetConfigCache()
+	})
+
+	// Init a git repo so getRepoRoot returns tempDir
+	cmd := exec.Command("git", "-C", tempDir, "init")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git init failed: %v", err)
+	}
+	os.Chdir(tempDir)
+
+	// Create config in the "repo root" (should take precedence)
 	localContent := `
 discovery:
   enabled: true
   template: "local/{branch}.md"
 `
-	err := os.WriteFile(".rune.yml", []byte(localContent), 0644)
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, ".rune.yml"), []byte(localContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(".rune.yml")
 
-	// Also create a home config (which should be ignored)
-	homeDir, _ := os.UserHomeDir()
-	homeConfigDir := filepath.Join(homeDir, ".config", "rune")
-	os.MkdirAll(homeConfigDir, 0755)
-	homeConfigPath := filepath.Join(homeConfigDir, "config.yml")
+	// Create a home config (should be ignored due to lower precedence)
+	homeConfigDir := filepath.Join(fakeHome, ".config", "rune")
+	if err := os.MkdirAll(homeConfigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 	homeContent := `
 discovery:
   enabled: false
   template: "home/{branch}.md"
 `
-	err = os.WriteFile(homeConfigPath, []byte(homeContent), 0644)
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(homeConfigDir, "config.yml"), []byte(homeContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(homeConfigPath)
 
 	// Load config - should use local file
 	cfg, err := LoadConfig()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,6 +31,7 @@ discovery:
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			resetConfigCache()
 			t.Cleanup(func() { resetConfigCache() })
 
 			// Isolate: work in a temp directory with a fake HOME

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,28 +32,20 @@ discovery:
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			resetConfigCache()
+			t.Cleanup(func() { resetConfigCache() })
 
 			// Isolate: work in a temp directory with a fake HOME
 			tempDir := t.TempDir()
 			fakeHome := t.TempDir()
 			t.Setenv("HOME", fakeHome)
 
-			originalDir, err := os.Getwd()
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Cleanup(func() {
-				os.Chdir(originalDir)
-				resetConfigCache()
-			})
-
-			// Init a git repo so getRepoRoot works
+			// Init a git repo so getRepoRoot (which shells out to git rev-parse) works
 			cmd := exec.Command("git", "-C", tempDir, "init")
 			if err := cmd.Run(); err != nil {
 				t.Fatalf("git init failed: %v", err)
 			}
 
-			os.Chdir(tempDir)
+			t.Chdir(tempDir)
 
 			if tc.writeConfig {
 				if err := os.WriteFile(filepath.Join(tempDir, ".rune.yml"), []byte(tc.content), 0644); err != nil {
@@ -213,22 +205,14 @@ func TestConfigPrecedence(t *testing.T) {
 	tempDir := t.TempDir()
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Cleanup(func() { resetConfigCache() })
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		os.Chdir(originalDir)
-		resetConfigCache()
-	})
-
-	// Init a git repo so getRepoRoot returns tempDir
+	// Init a git repo so getRepoRoot (which shells out to git rev-parse) works
 	cmd := exec.Command("git", "-C", tempDir, "init")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("git init failed: %v", err)
 	}
-	os.Chdir(tempDir)
+	t.Chdir(tempDir)
 
 	// Create config in the "repo root" (should take precedence)
 	localContent := `
@@ -276,14 +260,7 @@ func TestLoadConfigFromSubdirectory(t *testing.T) {
 
 	// Create a temp directory simulating a repo root
 	tempDir := t.TempDir()
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get working directory: %v", err)
-	}
-	t.Cleanup(func() {
-		os.Chdir(originalDir)
-		resetConfigCache()
-	})
+	t.Cleanup(func() { resetConfigCache() })
 
 	// Create .rune.yml at the "repo root" with a distinctive template
 	// that differs from the default, so we can prove it was actually loaded
@@ -302,13 +279,13 @@ discovery:
 		t.Fatal(err)
 	}
 
-	// Initialize a git repo so rev-parse --show-toplevel works
+	// Initialize a git repo so getRepoRoot (which shells out to git rev-parse) works
 	cmd := exec.Command("git", "-C", tempDir, "init")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to init git repo: %v", err)
 	}
 
-	os.Chdir(subDir)
+	t.Chdir(subDir)
 
 	cfg, err := loadConfigUncached()
 	if err != nil {
@@ -327,17 +304,10 @@ discovery:
 // silently falling back to defaults. Regression test for T-556.
 func TestLoadConfigUncachedInvalidYAML(t *testing.T) {
 	resetConfigCache()
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get working directory: %v", err)
-	}
 	tempDir := t.TempDir()
-	t.Cleanup(func() {
-		os.Chdir(originalDir)
-		resetConfigCache()
-	})
+	t.Cleanup(func() { resetConfigCache() })
 
-	// Initialize git repo so getRepoRoot works
+	// Initialize git repo so getRepoRoot (which shells out to git rev-parse) works
 	cmd := exec.Command("git", "-C", tempDir, "init")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to init git repo: %v", err)
@@ -352,7 +322,7 @@ func TestLoadConfigUncachedInvalidYAML(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	os.Chdir(tempDir)
+	t.Chdir(tempDir)
 
 	cfg, err := loadConfigUncached()
 	if err == nil {
@@ -367,16 +337,10 @@ func TestLoadConfigUncachedInvalidYAML(t *testing.T) {
 // unknown fields, loadConfigUncached returns an error. Regression test for T-556.
 func TestLoadConfigUncachedUnknownFields(t *testing.T) {
 	resetConfigCache()
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get working directory: %v", err)
-	}
 	tempDir := t.TempDir()
-	t.Cleanup(func() {
-		os.Chdir(originalDir)
-		resetConfigCache()
-	})
+	t.Cleanup(func() { resetConfigCache() })
 
+	// Initialize git repo so getRepoRoot (which shells out to git rev-parse) works
 	cmd := exec.Command("git", "-C", tempDir, "init")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to init git repo: %v", err)
@@ -391,7 +355,7 @@ func TestLoadConfigUncachedUnknownFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	os.Chdir(tempDir)
+	t.Chdir(tempDir)
 
 	cfg, err := loadConfigUncached()
 	if err == nil {
@@ -471,15 +435,8 @@ discovery:
 // .rune.yml exists, defaults are still returned (not broken by T-556 fix).
 func TestLoadConfigUncachedMissingFileStillDefaults(t *testing.T) {
 	resetConfigCache()
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get working directory: %v", err)
-	}
 	tempDir := t.TempDir()
-	t.Cleanup(func() {
-		os.Chdir(originalDir)
-		resetConfigCache()
-	})
+	t.Cleanup(func() { resetConfigCache() })
 
 	// Initialize git repo but do NOT create .rune.yml
 	cmd := exec.Command("git", "-C", tempDir, "init")
@@ -487,7 +444,7 @@ func TestLoadConfigUncachedMissingFileStillDefaults(t *testing.T) {
 		t.Fatalf("Failed to init git repo: %v", err)
 	}
 
-	os.Chdir(tempDir)
+	t.Chdir(tempDir)
 
 	cfg, err := loadConfigUncached()
 	if err != nil {

--- a/specs/bugfixes/config-tests-write-real-home/report.md
+++ b/specs/bugfixes/config-tests-write-real-home/report.md
@@ -1,0 +1,77 @@
+# Bugfix Report: config-tests-write-real-home
+
+**Date:** 2026-04-16
+**Status:** Fixed
+
+## Description of the Issue
+
+Config tests in `internal/config/config_test.go` wrote to the developer's real home directory (`~/.config/rune/config.yml`) and the project's working directory (`.rune.yml`), making the test suite not self-contained.
+
+**Reproduction steps:**
+1. Run `make test` in a sandboxed environment where `~/.config/rune/` is outside the writable sandbox
+2. `TestConfigPrecedence` calls `os.UserHomeDir()` and creates `~/.config/rune/config.yml`
+3. Test fails with `operation not permitted`
+
+**Impact:** Tests fail in any sandboxed CI environment (e.g., Codex) unless `HOME` is explicitly overridden. Also risks polluting developer home directories with test artifacts.
+
+## Investigation Summary
+
+- **Symptoms examined:** `open /Users/arjen/.config/rune/config.yml: operation not permitted` during `make test`
+- **Code inspected:** `internal/config/config_test.go` — `TestConfigPrecedence`, `TestLoadConfig`, `TestExpandHome`
+- **Hypotheses tested:** Confirmed `os.UserHomeDir()` at line 226 resolves to real home; no `t.Setenv("HOME", ...)` isolation present
+
+## Discovered Root Cause
+
+`TestConfigPrecedence` used the real `os.UserHomeDir()` to create a config file under `~/.config/rune/`, writing outside the test sandbox.
+
+`TestLoadConfig` wrote `.rune.yml` to the actual project CWD instead of an isolated temp directory.
+
+`TestExpandHome` referenced the real `HOME` env var, making assertions dependent on the host environment.
+
+**Defect type:** Missing test isolation
+
+**Why it occurred:** Tests were written before sandboxed execution was a requirement.
+
+**Contributing factors:** `os.UserHomeDir()` is easy to call directly; Go's `t.Setenv` + `t.TempDir` pattern for HOME isolation isn't enforced by convention.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/config/config_test.go` — `TestConfigPrecedence`: Redirected HOME to `t.TempDir()` via `t.Setenv`, created an isolated git repo in a temp dir, writes config files only within temp dirs
+- `internal/config/config_test.go` — `TestLoadConfig`: Same isolation pattern — chdir to temp dir with git repo, fake HOME
+- `internal/config/config_test.go` — `TestExpandHome`: Set HOME to a known temp dir for deterministic assertions
+
+**Approach rationale:** `t.Setenv("HOME", ...)` is the standard Go approach — it's automatically restored after the test and works with `os.UserHomeDir()`.
+
+**Alternatives considered:**
+- Mocking `os.UserHomeDir` via a package-level var — more invasive, unnecessary when `t.Setenv` works
+
+## Regression Test
+
+The fixed tests themselves serve as regression tests. `TestConfigPrecedence` now proves that both local and home config files are found using only isolated temp directories.
+
+**Run command:** `go test -v -run 'TestLoadConfig$|TestExpandHome|TestConfigPrecedence' ./internal/config/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/config/config_test.go` | Isolate HOME and CWD in TestConfigPrecedence, TestLoadConfig, TestExpandHome |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`go test ./...`)
+- [x] Code formatted (`make fmt`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Always use `t.Setenv("HOME", t.TempDir())` in tests that touch home-directory paths
+- Never call `os.UserHomeDir()` directly in tests without first isolating HOME
+- Tests that write files should operate in `t.TempDir()`, not the project CWD
+
+## Related
+
+- Transit T-812: Config tests write to real home directory


### PR DESCRIPTION
## Bug

`TestConfigPrecedence` in `internal/config/config_test.go` called `os.UserHomeDir()` and wrote to `~/.config/rune/config.yml`, causing `operation not permitted` in sandboxed CI environments. `TestLoadConfig` similarly wrote `.rune.yml` to the project CWD.

## Root Cause

Tests lacked HOME isolation — they used the real home directory and working directory for file operations instead of temp directories.

## Fix

All three affected tests (`TestConfigPrecedence`, `TestLoadConfig`, `TestExpandHome`) now use `t.Setenv("HOME", t.TempDir())` and operate entirely within isolated temp directories with their own git repos.

## Verification

- All config tests pass
- Full test suite passes (`go test ./...`)
- Bugfix report: `specs/bugfixes/config-tests-write-real-home/report.md`

Fixes T-812