### PR TITLE
Fix T-806: Remove leaves stale blocker

### DIFF
--- a/internal/task/batch.go
+++ b/internal/task/batch.go
@@ -407,7 +407,8 @@ func applyOperation(tl *TaskList, op Operation) error {
 	case addOperation:
 		return applyAddOperation(tl, op)
 	case removeOperation:
-		return tl.RemoveTask(op.ID)
+		_, err := tl.RemoveTaskWithDependents(op.ID)
+		return err
 	case updateOperation:
 		return applyUpdateOperation(tl, op)
 	default:
@@ -751,7 +752,8 @@ func applyOperationWithPhases(tl *TaskList, op Operation, autoCompleted map[stri
 		return updateTaskDetailsAndReferences(tl, newTaskID, op.Details, op.References, op.Requirements)
 	case removeOperation:
 		adjustPhaseMarkersForRemoval(op.ID, phaseMarkers)
-		return tl.RemoveTask(op.ID)
+		_, err := tl.RemoveTaskWithDependents(op.ID)
+		return err
 	case updateOperation:
 		// Apply field updates BEFORE status to avoid partial mutation if
 		// UpdateTask/UpdateTaskWithOptions rejects invalid content.

--- a/internal/task/operations.go
+++ b/internal/task/operations.go
@@ -772,14 +772,14 @@ func (tl *TaskList) RemoveTaskWithPhases(taskID string, originalContent []byte) 
 
 	// If no phases, just use regular operations
 	if len(phaseMarkers) == 0 {
-		if err := tl.RemoveTask(taskID); err != nil {
+		if _, err := tl.RemoveTaskWithDependents(taskID); err != nil {
 			return err
 		}
 		return tl.WriteFile(tl.FilePath)
 	}
 
-	// Remove the task
-	if err := tl.RemoveTask(taskID); err != nil {
+	// Remove the task (cleans up stale BlockedBy references)
+	if _, err := tl.RemoveTaskWithDependents(taskID); err != nil {
 		return err
 	}
 

--- a/internal/task/operations.go
+++ b/internal/task/operations.go
@@ -165,10 +165,10 @@ func (tl *TaskList) addTaskAtPosition(parentID, title, position string) (string,
 	return newTaskID, nil
 }
 
+// RemoveTask removes a task from the task list and renumbers remaining tasks.
+//
 // Deprecated: Use RemoveTaskWithDependents to ensure BlockedBy references
 // are cleaned up. RemoveTask only removes the task and renumbers.
-//
-// RemoveTask removes a task from the task list and renumbers remaining tasks
 func (tl *TaskList) RemoveTask(taskID string) error {
 	if removed := tl.removeTaskRecursive(&tl.Tasks, taskID, ""); removed {
 		tl.RenumberTasks()

--- a/internal/task/operations.go
+++ b/internal/task/operations.go
@@ -165,6 +165,9 @@ func (tl *TaskList) addTaskAtPosition(parentID, title, position string) (string,
 	return newTaskID, nil
 }
 
+// Deprecated: Use RemoveTaskWithDependents to ensure BlockedBy references
+// are cleaned up. RemoveTask only removes the task and renumbers.
+//
 // RemoveTask removes a task from the task list and renumbers remaining tasks
 func (tl *TaskList) RemoveTask(taskID string) error {
 	if removed := tl.removeTaskRecursive(&tl.Tasks, taskID, ""); removed {

--- a/internal/task/operations_extended_test.go
+++ b/internal/task/operations_extended_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"os"
 	"testing"
 )
 
@@ -756,4 +757,85 @@ func TestCollectStableIDs(t *testing.T) {
 			t.Errorf("expected 1 stable ID (excluding legacy), got %d", len(ids))
 		}
 	})
+}
+
+// T-806 regression: RemoveTaskWithPhases must clean up stale BlockedBy refs.
+func TestRemoveTaskWithPhases_CleansBlockedBy(t *testing.T) {
+	tl := &TaskList{Title: "Test Tasks"}
+
+	// Create blocker task with stable ID
+	blockerId, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+	blockerTask := tl.FindTask(blockerId)
+	blockerStableID := blockerTask.StableID
+
+	// Create dependent task blocked by the first
+	depId, _ := tl.AddTaskWithOptions("", "Dependent", AddOptions{
+		BlockedBy: []string{blockerId},
+	})
+
+	depTask := tl.FindTask(depId)
+	if len(depTask.BlockedBy) != 1 || depTask.BlockedBy[0] != blockerStableID {
+		t.Fatalf("precondition: expected dependent blocked by %q, got %v", blockerStableID, depTask.BlockedBy)
+	}
+
+	// Render to markdown so RemoveTaskWithPhases has original content
+	md := RenderMarkdown(tl)
+	tl.FilePath = "t806_test_phases.md"
+	defer os.Remove("t806_test_phases.md")
+
+	// Remove the blocker via the phase-aware path (no actual phases)
+	if err := tl.RemoveTaskWithPhases(blockerId, md); err != nil {
+		t.Fatalf("RemoveTaskWithPhases failed: %v", err)
+	}
+
+	// After removal, the remaining task (renumbered to "1") must NOT reference
+	// the deleted blocker's stable ID.
+	remaining := tl.FindTask("1")
+	if remaining == nil {
+		t.Fatal("expected remaining task at ID 1")
+	}
+	if len(remaining.BlockedBy) != 0 {
+		t.Errorf("T-806: stale BlockedBy reference not cleaned up, got %v", remaining.BlockedBy)
+	}
+}
+
+// T-806 regression: batch remove must clean up stale BlockedBy refs.
+func TestBatchRemove_CleansBlockedBy(t *testing.T) {
+	tl := &TaskList{Title: "Test Tasks"}
+
+	// Create blocker and dependent
+	blockerId, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+	blockerTask := tl.FindTask(blockerId)
+	blockerStableID := blockerTask.StableID
+
+	depId, _ := tl.AddTaskWithOptions("", "Dependent", AddOptions{
+		BlockedBy: []string{blockerId},
+	})
+
+	depTask := tl.FindTask(depId)
+	if len(depTask.BlockedBy) != 1 || depTask.BlockedBy[0] != blockerStableID {
+		t.Fatalf("precondition: expected dependent blocked by %q, got %v", blockerStableID, depTask.BlockedBy)
+	}
+
+	// Execute a batch remove operation
+	ops := []Operation{
+		{Type: "remove", ID: blockerId},
+	}
+
+	resp, err := tl.ExecuteBatch(ops, false)
+	if err != nil {
+		t.Fatalf("batch remove failed: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("batch remove not successful: errors=%v", resp.Errors)
+	}
+
+	// The remaining task must have no stale BlockedBy
+	remaining := tl.FindTask("1")
+	if remaining == nil {
+		t.Fatal("expected remaining task at ID 1")
+	}
+	if len(remaining.BlockedBy) != 0 {
+		t.Errorf("T-806: stale BlockedBy reference not cleaned up after batch remove, got %v", remaining.BlockedBy)
+	}
 }

--- a/internal/task/operations_extended_test.go
+++ b/internal/task/operations_extended_test.go
@@ -58,19 +58,19 @@ func TestAddTaskWithOptions(t *testing.T) {
 		tl := &TaskList{Title: "Test Tasks"}
 
 		// First add a task that will be the blocker
-		blockerId, err := tl.AddTaskWithOptions("", "Blocker task", AddOptions{})
+		blockerID, err := tl.AddTaskWithOptions("", "Blocker task", AddOptions{})
 		if err != nil {
 			t.Fatalf("AddTaskWithOptions failed: %v", err)
 		}
 
-		blockerTask := tl.FindTask(blockerId)
+		blockerTask := tl.FindTask(blockerID)
 		if blockerTask == nil {
 			t.Fatal("blocker task not found")
 		}
 
 		// Add a task blocked by the first task
 		id, err := tl.AddTaskWithOptions("", "Blocked task", AddOptions{
-			BlockedBy: []string{blockerId}, // Using hierarchical ID
+			BlockedBy: []string{blockerID}, // Using hierarchical ID
 		})
 		if err != nil {
 			t.Fatalf("AddTaskWithOptions failed: %v", err)
@@ -151,7 +151,7 @@ func TestAddTaskWithOptions(t *testing.T) {
 		tl := &TaskList{Title: "Test Tasks"}
 
 		// Create a blocker task first
-		blockerId, err := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+		blockerID, err := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
 		if err != nil {
 			t.Fatalf("AddTaskWithOptions failed: %v", err)
 		}
@@ -159,7 +159,7 @@ func TestAddTaskWithOptions(t *testing.T) {
 		// Add task with all options
 		id, err := tl.AddTaskWithOptions("", "Full options task", AddOptions{
 			Stream:    2,
-			BlockedBy: []string{blockerId},
+			BlockedBy: []string{blockerID},
 			Owner:     "agent-2",
 		})
 		if err != nil {
@@ -417,9 +417,9 @@ func TestUpdateTaskWithOptions(t *testing.T) {
 	t.Run("UpdateTask clearing blocked-by", func(t *testing.T) {
 		tl := &TaskList{Title: "Test Tasks"}
 
-		blockerId, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+		blockerID, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
 		taskId, _ := tl.AddTaskWithOptions("", "Task", AddOptions{
-			BlockedBy: []string{blockerId},
+			BlockedBy: []string{blockerID},
 		})
 
 		// Clear blocked-by with empty slice
@@ -446,20 +446,20 @@ func TestRemoveTaskWithDependents(t *testing.T) {
 		tl := &TaskList{Title: "Test Tasks"}
 
 		// Create a task that others will depend on
-		blockerId, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
-		blockerTask := tl.FindTask(blockerId)
+		blockerID, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+		blockerTask := tl.FindTask(blockerID)
 		blockerStableID := blockerTask.StableID
 
 		// Create tasks that depend on it
 		tl.AddTaskWithOptions("", "Dependent 1", AddOptions{
-			BlockedBy: []string{blockerId},
+			BlockedBy: []string{blockerID},
 		})
 		tl.AddTaskWithOptions("", "Dependent 2", AddOptions{
-			BlockedBy: []string{blockerId},
+			BlockedBy: []string{blockerID},
 		})
 
 		// Remove the blocker task (it's at ID "1", so after removal IDs will shift)
-		warnings, err := tl.RemoveTaskWithDependents(blockerId)
+		warnings, err := tl.RemoveTaskWithDependents(blockerID)
 		if err != nil {
 			t.Fatalf("RemoveTaskWithDependents failed: %v", err)
 		}
@@ -491,15 +491,15 @@ func TestRemoveTaskWithDependents(t *testing.T) {
 		tl := &TaskList{Title: "Test Tasks"}
 
 		// Create blocker and dependent
-		blockerId, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
-		blockerTask := tl.FindTask(blockerId)
+		blockerID, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+		blockerTask := tl.FindTask(blockerID)
 
-		depId, _ := tl.AddTaskWithOptions("", "Dependent", AddOptions{
-			BlockedBy: []string{blockerId},
+		depID, _ := tl.AddTaskWithOptions("", "Dependent", AddOptions{
+			BlockedBy: []string{blockerID},
 		})
 
 		// Verify dependent has the blocker in its BlockedBy
-		depTask := tl.FindTask(depId)
+		depTask := tl.FindTask(depID)
 		if len(depTask.BlockedBy) != 1 {
 			t.Fatalf("expected 1 blocker, got %d", len(depTask.BlockedBy))
 		}
@@ -508,7 +508,7 @@ func TestRemoveTaskWithDependents(t *testing.T) {
 		}
 
 		// Remove the blocker
-		_, err := tl.RemoveTaskWithDependents(blockerId)
+		_, err := tl.RemoveTaskWithDependents(blockerID)
 		if err != nil {
 			t.Fatalf("RemoveTaskWithDependents failed: %v", err)
 		}
@@ -555,11 +555,11 @@ func TestRemoveTaskWithDependents(t *testing.T) {
 		tl := &TaskList{Title: "Test Tasks"}
 
 		// Create task A with a stable ID (the blocker)
-		blockerId, err := tl.AddTaskWithOptions("", "Blocker A", AddOptions{})
+		blockerID, err := tl.AddTaskWithOptions("", "Blocker A", AddOptions{})
 		if err != nil {
 			t.Fatalf("AddTaskWithOptions failed: %v", err)
 		}
-		blockerTask := tl.FindTask(blockerId)
+		blockerTask := tl.FindTask(blockerID)
 		blockerStableID := blockerTask.StableID
 
 		// Create task B without a stable ID but with BlockedBy referencing A.
@@ -576,7 +576,7 @@ func TestRemoveTaskWithDependents(t *testing.T) {
 		})
 
 		// Remove the blocker
-		_, err = tl.RemoveTaskWithDependents(blockerId)
+		_, err = tl.RemoveTaskWithDependents(blockerID)
 		if err != nil {
 			t.Fatalf("RemoveTaskWithDependents failed: %v", err)
 		}
@@ -764,27 +764,41 @@ func TestRemoveTaskWithPhases_CleansBlockedBy(t *testing.T) {
 	tl := &TaskList{Title: "Test Tasks"}
 
 	// Create blocker task with stable ID
-	blockerId, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
-	blockerTask := tl.FindTask(blockerId)
+	blockerID, err := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+	if err != nil {
+		t.Fatalf("failed to add blocker task: %v", err)
+	}
+	blockerTask := tl.FindTask(blockerID)
 	blockerStableID := blockerTask.StableID
 
 	// Create dependent task blocked by the first
-	depId, _ := tl.AddTaskWithOptions("", "Dependent", AddOptions{
-		BlockedBy: []string{blockerId},
+	depID, err := tl.AddTaskWithOptions("", "Dependent", AddOptions{
+		BlockedBy: []string{blockerID},
 	})
+	if err != nil {
+		t.Fatalf("failed to add dependent task: %v", err)
+	}
 
-	depTask := tl.FindTask(depId)
+	depTask := tl.FindTask(depID)
 	if len(depTask.BlockedBy) != 1 || depTask.BlockedBy[0] != blockerStableID {
 		t.Fatalf("precondition: expected dependent blocked by %q, got %v", blockerStableID, depTask.BlockedBy)
 	}
 
 	// Render to markdown so RemoveTaskWithPhases has original content
 	md := RenderMarkdown(tl)
+	dir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer os.Chdir(originalDir)
 	tl.FilePath = "t806_test_phases.md"
-	defer os.Remove("t806_test_phases.md")
 
 	// Remove the blocker via the phase-aware path (no actual phases)
-	if err := tl.RemoveTaskWithPhases(blockerId, md); err != nil {
+	if err := tl.RemoveTaskWithPhases(blockerID, md); err != nil {
 		t.Fatalf("RemoveTaskWithPhases failed: %v", err)
 	}
 
@@ -804,22 +818,28 @@ func TestBatchRemove_CleansBlockedBy(t *testing.T) {
 	tl := &TaskList{Title: "Test Tasks"}
 
 	// Create blocker and dependent
-	blockerId, _ := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
-	blockerTask := tl.FindTask(blockerId)
+	blockerID, err := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+	if err != nil {
+		t.Fatalf("failed to add blocker task: %v", err)
+	}
+	blockerTask := tl.FindTask(blockerID)
 	blockerStableID := blockerTask.StableID
 
-	depId, _ := tl.AddTaskWithOptions("", "Dependent", AddOptions{
-		BlockedBy: []string{blockerId},
+	depID, err := tl.AddTaskWithOptions("", "Dependent", AddOptions{
+		BlockedBy: []string{blockerID},
 	})
+	if err != nil {
+		t.Fatalf("failed to add dependent task: %v", err)
+	}
 
-	depTask := tl.FindTask(depId)
+	depTask := tl.FindTask(depID)
 	if len(depTask.BlockedBy) != 1 || depTask.BlockedBy[0] != blockerStableID {
 		t.Fatalf("precondition: expected dependent blocked by %q, got %v", blockerStableID, depTask.BlockedBy)
 	}
 
 	// Execute a batch remove operation
 	ops := []Operation{
-		{Type: "remove", ID: blockerId},
+		{Type: "remove", ID: blockerID},
 	}
 
 	resp, err := tl.ExecuteBatch(ops, false)
@@ -837,5 +857,77 @@ func TestBatchRemove_CleansBlockedBy(t *testing.T) {
 	}
 	if len(remaining.BlockedBy) != 0 {
 		t.Errorf("T-806: stale BlockedBy reference not cleaned up after batch remove, got %v", remaining.BlockedBy)
+	}
+}
+
+// T-806 regression: ExecuteBatchWithPhases remove must clean up stale BlockedBy refs.
+func TestBatchRemoveWithPhases_CleansBlockedBy(t *testing.T) {
+	tl := &TaskList{Title: "Test Tasks"}
+
+	// Create blocker and dependent
+	blockerID, err := tl.AddTaskWithOptions("", "Blocker", AddOptions{})
+	if err != nil {
+		t.Fatalf("failed to add blocker task: %v", err)
+	}
+	blockerTask := tl.FindTask(blockerID)
+	blockerStableID := blockerTask.StableID
+
+	depID, err := tl.AddTaskWithOptions("", "Dependent", AddOptions{
+		BlockedBy: []string{blockerID},
+	})
+	if err != nil {
+		t.Fatalf("failed to add dependent task: %v", err)
+	}
+
+	depTask := tl.FindTask(depID)
+	if len(depTask.BlockedBy) != 1 || depTask.BlockedBy[0] != blockerStableID {
+		t.Fatalf("precondition: expected dependent blocked by %q, got %v", blockerStableID, depTask.BlockedBy)
+	}
+
+	// Set up a file path for phase-aware batch (it writes to disk)
+	dir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer os.Chdir(originalDir)
+
+	filePath := "t806_batch_phases.md"
+	tl.FilePath = filePath
+
+	// Write initial content so ExecuteBatchWithPhases can read/write
+	md := RenderMarkdown(tl)
+	if err := os.WriteFile(filePath, md, 0o644); err != nil {
+		t.Fatalf("failed to write initial file: %v", err)
+	}
+
+	// Use phase markers to force the ExecuteBatchWithPhases path
+	// (without phase markers it falls through to ExecuteBatch)
+	phaseMarkers := []PhaseMarker{
+		{Name: "Phase 1", AfterTaskID: ""},
+	}
+
+	ops := []Operation{
+		{Type: "remove", ID: blockerID},
+	}
+
+	resp, err := tl.ExecuteBatchWithPhases(ops, false, phaseMarkers, filePath)
+	if err != nil {
+		t.Fatalf("batch remove with phases failed: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("batch remove with phases not successful: errors=%v", resp.Errors)
+	}
+
+	// The remaining task must have no stale BlockedBy
+	remaining := tl.FindTask("1")
+	if remaining == nil {
+		t.Fatal("expected remaining task at ID 1")
+	}
+	if len(remaining.BlockedBy) != 0 {
+		t.Errorf("T-806: stale BlockedBy reference not cleaned up after batch remove with phases, got %v", remaining.BlockedBy)
 	}
 }

--- a/specs/bugfixes/remove-leaves-stale-blocker/report.md
+++ b/specs/bugfixes/remove-leaves-stale-blocker/report.md
@@ -1,0 +1,75 @@
+# Bugfix Report: Remove Leaves Stale Blocker
+
+**Date:** 2026-04-16
+**Status:** Fixed
+**Ticket:** T-806
+
+## Description of the Issue
+
+When removing a task that has a `StableID` referenced by other tasks' `BlockedBy` lists, the stale reference was not cleaned up. The dependent task continued to render `Blocked-by: <deleted-stable-id>`, pointing at a non-existent blocker.
+
+**Reproduction steps:**
+1. Create task 1 with stable ID `abc1234`
+2. Create task 2 with `Blocked-by: abc1234`
+3. Run `rune remove <file> 1`
+4. Observe: task 2 (renumbered to 1) still renders `Blocked-by: abc1234`
+
+**Impact:** Medium — tasks could be permanently blocked by deleted tasks, with no way to unblock them short of manually editing the markdown.
+
+## Investigation Summary
+
+- **Symptoms examined:** Stale `BlockedBy` references after task removal
+- **Code inspected:** `cmd/remove.go`, `internal/task/operations.go`, `internal/task/batch.go`
+- **Hypotheses tested:** The correct cleanup helper `RemoveTaskWithDependents` exists but is bypassed
+
+## Discovered Root Cause
+
+Three remove code paths called `RemoveTask()` instead of `RemoveTaskWithDependents()`:
+
+1. `RemoveTaskWithPhases()` in `operations.go` — used by `cmd/remove.go`
+2. `applyOperation()` in `batch.go` — used by non-phase batch removes
+3. `applyOperationWithPhases()` in `batch.go` — used by phase-aware batch removes
+
+`RemoveTask()` only removes the task and renumbers. `RemoveTaskWithDependents()` additionally walks the entire task tree and removes the deleted task's `StableID` from all `BlockedBy` lists before removing.
+
+**Defect type:** Missing function call — correct helper bypassed
+
+**Why it occurred:** `RemoveTaskWithDependents` was added after the original remove paths were written, but those paths were never updated to use it.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/task/operations.go:720-728` — `RemoveTaskWithPhases` now calls `RemoveTaskWithDependents` instead of `RemoveTask`
+- `internal/task/batch.go:410` — `applyOperation` remove case now calls `RemoveTaskWithDependents`
+- `internal/task/batch.go:754` — `applyOperationWithPhases` remove case now calls `RemoveTaskWithDependents`
+
+**Approach rationale:** The simplest correct fix — route all remove paths through the existing helper that already handles dependency cleanup. Warnings from `RemoveTaskWithDependents` are discarded since the callers have no warning channel, and the cleanup is silent by design.
+
+## Regression Test
+
+**Test file:** `internal/task/operations_extended_test.go`
+**Test names:** `TestRemoveTaskWithPhases_CleansBlockedBy`, `TestBatchRemove_CleansBlockedBy`
+
+**What they verify:** After removing a blocker task, the remaining dependent task's `BlockedBy` list is empty.
+
+**Run command:** `go test -run "TestRemoveTaskWithPhases_CleansBlockedBy|TestBatchRemove_CleansBlockedBy" ./internal/task/ -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/task/operations.go` | `RemoveTaskWithPhases` calls `RemoveTaskWithDependents` |
+| `internal/task/batch.go` | Both batch remove paths call `RemoveTaskWithDependents` |
+| `internal/task/operations_extended_test.go` | Added two regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes (`go test ./...`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- `RemoveTask()` should be unexported or deprecated — all callers should use `RemoveTaskWithDependents()` to ensure dependency cleanup is never bypassed.
+- Consider adding a linter rule or code review checklist item: "Does this remove path go through `RemoveTaskWithDependents`?"


### PR DESCRIPTION
## Bug

When removing a task with a `StableID` referenced by other tasks' `BlockedBy` lists, the stale reference was not cleaned up. Dependent tasks continued to render `Blocked-by: <deleted-id>`, pointing at a non-existent blocker.

## Root Cause

Three remove code paths called `RemoveTask()` instead of `RemoveTaskWithDependents()`:
- `RemoveTaskWithPhases()` in `operations.go` (CLI remove)
- `applyOperation()` in `batch.go` (batch remove)
- `applyOperationWithPhases()` in `batch.go` (phase-aware batch remove)

## Fix

Route all three paths through `RemoveTaskWithDependents()`, which walks the task tree and removes the deleted task's `StableID` from all `BlockedBy` lists.

## Testing

- Added `TestRemoveTaskWithPhases_CleansBlockedBy` — verifies CLI remove path
- Added `TestBatchRemove_CleansBlockedBy` — verifies batch remove path
- Full test suite passes

See `specs/bugfixes/remove-leaves-stale-blocker/report.md` for the full bugfix report.