### PR TITLE
Fix T-826: Install Instructions Wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A standalone Go command-line tool designed for AI agents and developers to creat
 ## Installation
 
 ```bash
-go install github.com/ArjenSchwarz/rune@latest
+go install github.com/arjenschwarz/rune@latest
 ```
 
 Or install from source:

--- a/docs/release_notes/RELEASE_NOTES_V1.1.0.md
+++ b/docs/release_notes/RELEASE_NOTES_V1.1.0.md
@@ -89,7 +89,7 @@ The test suite has been refactored to follow Go 2025 best practices:
 ### Go Install
 
 ```bash
-go install github.com/ArjenSchwarz/rune@v1.1.0
+go install github.com/arjenschwarz/rune@v1.1.0
 ```
 
 ### Build from Source

--- a/docs/release_notes/RELEASE_NOTES_V1.2.0.md
+++ b/docs/release_notes/RELEASE_NOTES_V1.2.0.md
@@ -118,7 +118,7 @@ The `list` command now shows Stream, BlockedBy, and Owner columns only when rele
 ### Go Install
 
 ```bash
-go install github.com/ArjenSchwarz/rune@v1.2.0
+go install github.com/arjenschwarz/rune@v1.2.0
 ```
 
 ### Build from Source

--- a/docs/release_notes/RELEASE_NOTES_V1.3.0.md
+++ b/docs/release_notes/RELEASE_NOTES_V1.3.0.md
@@ -48,7 +48,7 @@ If the positional argument conflicts with a `file` field in the JSON payload, a 
 ### Go Install
 
 ```bash
-go install github.com/ArjenSchwarz/rune@v1.3.0
+go install github.com/arjenschwarz/rune@v1.3.0
 ```
 
 ### Build from Source

--- a/specs/bugfixes/install-instructions-wrong/report.md
+++ b/specs/bugfixes/install-instructions-wrong/report.md
@@ -1,0 +1,74 @@
+# Bugfix Report: install-instructions-wrong
+
+**Date:** 2026-04-16
+**Status:** Fixed
+**Transit Ticket:** T-826
+
+## Description of the Issue
+
+The README and release notes contained incorrect `go install` commands using mixed-case `ArjenSchwarz/rune` instead of the lowercase `arjenschwarz/rune` that matches the Go module path declared in `go.mod`.
+
+**Reproduction steps:**
+1. Follow the install instructions: `go install github.com/ArjenSchwarz/rune@latest`
+2. Go reports a module path mismatch because the module is registered as `github.com/arjenschwarz/rune`
+
+**Impact:** Users cannot install rune using the documented `go install` command.
+
+## Investigation Summary
+
+- **Symptoms examined:** `go install` command in README uses `ArjenSchwarz/rune` (mixed case)
+- **Code inspected:** `go.mod` (module path), `README.md`, and release notes
+- **Hypotheses tested:** Confirmed Go module paths are case-sensitive; the module is registered as lowercase
+
+## Discovered Root Cause
+
+The `go install` commands in documentation used the GitHub username casing (`ArjenSchwarz`) instead of the Go module path casing (`arjenschwarz`). While GitHub URLs are case-insensitive, Go module paths are case-sensitive and must match `go.mod` exactly.
+
+**Defect type:** Documentation error
+
+**Why it occurred:** The GitHub username `ArjenSchwarz` has mixed case, which was used uniformly across all URLs and commands without distinguishing that `go install` requires the module path (lowercase).
+
+**Contributing factors:** GitHub URLs work with either casing, masking the issue for non-Go-install references.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `README.md:27` - Changed `go install github.com/ArjenSchwarz/rune@latest` to `go install github.com/arjenschwarz/rune@latest`
+- `docs/release_notes/RELEASE_NOTES_V1.1.0.md:92` - Fixed `go install` path to lowercase
+- `docs/release_notes/RELEASE_NOTES_V1.2.0.md:121` - Fixed `go install` path to lowercase
+- `docs/release_notes/RELEASE_NOTES_V1.3.0.md:51` - Fixed `go install` path to lowercase
+
+**Approach rationale:** Only `go install` commands were changed since Go modules require exact case matching. GitHub URLs, GitHub Actions references, and other links correctly use the GitHub username casing (GitHub is case-insensitive for these).
+
+**Alternatives considered:**
+- Change all references to lowercase — not appropriate since GitHub Actions `uses:` references and URLs work correctly with the display casing
+
+## Regression Test
+
+Not applicable — this is a documentation-only fix with no testable code changes.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `README.md` | Fixed `go install` module path to lowercase |
+| `docs/release_notes/RELEASE_NOTES_V1.1.0.md` | Fixed `go install` module path to lowercase |
+| `docs/release_notes/RELEASE_NOTES_V1.2.0.md` | Fixed `go install` module path to lowercase |
+| `docs/release_notes/RELEASE_NOTES_V1.3.0.md` | Fixed `go install` module path to lowercase |
+
+## Verification
+
+**Manual verification:**
+- Confirmed `go.mod` declares module as `github.com/arjenschwarz/rune` (lowercase)
+- Confirmed all `go install` commands now use matching lowercase path
+- Confirmed GitHub URLs and Actions references retain correct mixed-case (these are case-insensitive)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding `go install` commands, always copy the module path from `go.mod` rather than deriving it from the GitHub URL
+- Consider adding a CI check that greps for `go install` commands and validates they match the module path
+
+## Related
+
+- Transit ticket: T-826


### PR DESCRIPTION
## Bug

The `go install` commands in README.md and release notes used `ArjenSchwarz/rune` (mixed case) but the Go module path in `go.mod` is `arjenschwarz/rune` (lowercase). Since Go module paths are case-sensitive, the documented install command fails.

## Root Cause

GitHub username `ArjenSchwarz` has mixed case, which was used uniformly across all URLs and commands without distinguishing that `go install` requires the exact module path from `go.mod`.

## Fix

Changed all `go install` commands to use `github.com/arjenschwarz/rune` (lowercase, matching `go.mod`). GitHub URLs and Actions references retain mixed case since GitHub is case-insensitive for those.

## Files Changed

- `README.md` — Fixed `go install` module path
- `docs/release_notes/RELEASE_NOTES_V1.1.0.md` — Fixed `go install` module path
- `docs/release_notes/RELEASE_NOTES_V1.2.0.md` — Fixed `go install` module path
- `docs/release_notes/RELEASE_NOTES_V1.3.0.md` — Fixed `go install` module path

## Report

See `specs/bugfixes/install-instructions-wrong/report.md`

Fixes T-826