### PR TITLE
Fix T-820: Batch Remove Shifts Phase Boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Streams Command**: `streams --available --json` (and `streams --json`) now recomputes the `available` array from the filtered `streams` list, preventing stale stream IDs from appearing in `available` after `filterEmptyStreams` or `filterAvailableStreams` removes streams
+- **Batch Command**: Batch remove operations on phased files now preserve phase boundaries; previously, removes without an explicit `phase` field bypassed phase-aware execution, stripping all phase headers from the output
 - **Next Command**: `next --phase --claim AGENT` now correctly claims all ready tasks from the next phase instead of silently ignoring `--phase` and claiming only a single task
 - **Phase Parsing**: `ParseFileWithPhases` front-matter stripping no longer treats horizontal rules (`---`) after front matter as additional front-matter delimiters, which would cause phase markers after the rule to be silently dropped
 - **Phase Parsing**: Normalize CRLF line endings in all phase-related functions (`ParseFileWithPhases`, `ExtractPhaseMarkers`, `getTaskPhase`, `getNextPhaseTasks`, `FindNextPhaseTasks`, `FindNextPhaseTasksForStream`, and phase-aware operations) by introducing a `splitLines` helper that trims `\r` after splitting on `\n`

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -131,52 +131,39 @@ func runBatch(cmd *cobra.Command, args []string) error {
 		req.DryRun = true
 	}
 
-	// Check if any operations use phases or create new phases
+	// Always parse with phases so the file's own phase markers are detected.
+	// ExecuteBatchWithPhases falls back to regular execution when neither the
+	// file nor any operation involves phases, so this is safe for non-phased files.
+	var phaseMarkers []task.PhaseMarker
+	var response *task.BatchResponse
+	var taskList *task.TaskList
+
+	taskList, phaseMarkers, err = task.ParseFileWithPhases(req.File)
+	if err != nil {
+		return fmt.Errorf("loading task file: %w", err)
+	}
+
+	// Set requirements file path
+	if req.RequirementsFile != "" {
+		taskList.RequirementsFile = req.RequirementsFile
+	} else if taskList.RequirementsFile == "" {
+		taskList.RequirementsFile = task.DefaultRequirementsFile
+	}
+
+	// Check if any operations use phases and validate phase names
 	hasPhaseOps := slices.ContainsFunc(req.Operations, func(op task.Operation) bool {
 		return op.Phase != "" || strings.ToLower(op.Type) == "add-phase"
 	})
 
-	var response *task.BatchResponse
-	var taskList *task.TaskList
-
-	// Use phase-aware execution if needed
-	if hasPhaseOps {
-		// Parse file with phases
-		var phaseMarkers []task.PhaseMarker
-		taskList, phaseMarkers, err = task.ParseFileWithPhases(req.File)
-		if err != nil {
-			return fmt.Errorf("loading task file with phases: %w", err)
-		}
-
-		// Set requirements file path
-		if req.RequirementsFile != "" {
-			taskList.RequirementsFile = req.RequirementsFile
-		} else if taskList.RequirementsFile == "" {
-			taskList.RequirementsFile = task.DefaultRequirementsFile
-		}
-
-		// Execute batch operations with phase support
+	if len(phaseMarkers) > 0 || hasPhaseOps {
+		// Use phase-aware execution to preserve phase boundaries
 		response, err = taskList.ExecuteBatchWithPhases(req.Operations, req.DryRun, phaseMarkers, req.File)
 		if err != nil {
-			return fmt.Errorf("executing batch operations with phases: %w", err)
+			return fmt.Errorf("executing batch operations: %w", err)
 		}
-
 		// File is already saved by ExecuteBatchWithPhases if not a dry run
 	} else {
-		// Load task list without phases
-		taskList, err = task.ParseFile(req.File)
-		if err != nil {
-			return fmt.Errorf("loading task file: %w", err)
-		}
-
-		// Set requirements file path
-		if req.RequirementsFile != "" {
-			taskList.RequirementsFile = req.RequirementsFile
-		} else if taskList.RequirementsFile == "" {
-			taskList.RequirementsFile = task.DefaultRequirementsFile
-		}
-
-		// Execute batch operations
+		// No phases involved — use regular batch execution
 		response, err = taskList.ExecuteBatch(req.Operations, req.DryRun)
 		if err != nil {
 			return fmt.Errorf("executing batch operations: %w", err)

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -573,3 +573,102 @@ func TestBatchCommand_MaxOperationsLimit(t *testing.T) {
 		t.Errorf("Expected operation limit error, got: %v", err)
 	}
 }
+
+// TestBatchCommand_RemoveOnPhasedFilePreservesPhases verifies that batch remove
+// operations on a file with phases preserve the phase structure (T-820).
+// The bug was that cmd/batch.go only used phase-aware execution when an operation
+// explicitly referenced a phase, so plain removes on phased files would strip
+// all phase headers.
+func TestBatchCommand_RemoveOnPhasedFilePreservesPhases(t *testing.T) {
+	tmpDir := t.TempDir()
+	taskFile := filepath.Join(tmpDir, "test_tasks.md")
+
+	initialContent := `# Test Tasks
+
+## Planning
+
+- [ ] 1. Define requirements
+- [ ] 2. Create design
+
+## Implementation
+
+- [ ] 3. Write code
+- [ ] 4. Write tests
+
+## Deployment
+
+- [ ] 5. Deploy to staging
+- [ ] 6. Deploy to production
+`
+	if err := os.WriteFile(taskFile, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+	os.Chdir(tmpDir)
+
+	resetBatchFlags()
+
+	// Batch remove tasks 1 and 3 — no phase field set on any operation
+	req := task.BatchRequest{
+		File: "test_tasks.md",
+		Operations: []task.Operation{
+			{Type: "remove", ID: "1"},
+			{Type: "remove", ID: "3"},
+		},
+	}
+
+	jsonData, _ := json.Marshal(req)
+
+	var output bytes.Buffer
+	rootCmd.SetOut(&output)
+	rootCmd.SetArgs([]string{"batch", "--input", string(jsonData), "--format", "json"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Batch command failed: %v", err)
+	}
+
+	// Re-read the file
+	updatedContent, err := os.ReadFile(taskFile)
+	if err != nil {
+		t.Fatalf("Failed to read updated file: %v", err)
+	}
+
+	contentStr := string(updatedContent)
+
+	// Phase headers must be preserved
+	if !strings.Contains(contentStr, "## Planning") {
+		t.Error("Planning phase header was lost after batch remove")
+	}
+	if !strings.Contains(contentStr, "## Implementation") {
+		t.Error("Implementation phase header was lost after batch remove")
+	}
+	if !strings.Contains(contentStr, "## Deployment") {
+		t.Error("Deployment phase header was lost after batch remove")
+	}
+
+	// Verify task positions relative to phase headers
+	planningIdx := strings.Index(contentStr, "## Planning")
+	implIdx := strings.Index(contentStr, "## Implementation")
+	deployIdx := strings.Index(contentStr, "## Deployment")
+
+	designIdx := strings.Index(contentStr, "Create design")
+	testsIdx := strings.Index(contentStr, "Write tests")
+	stagingIdx := strings.Index(contentStr, "Deploy to staging")
+
+	// "Create design" should be between Planning and Implementation
+	if designIdx < planningIdx || designIdx > implIdx {
+		t.Error("'Create design' should be in Planning phase")
+	}
+
+	// "Write tests" should be between Implementation and Deployment
+	if testsIdx < implIdx || testsIdx > deployIdx {
+		t.Error("'Write tests' should be in Implementation phase")
+	}
+
+	// "Deploy to staging" should be after Deployment
+	if stagingIdx < deployIdx {
+		t.Error("'Deploy to staging' should be in Deployment phase")
+	}
+}

--- a/specs/bugfixes/batch-remove-shifts-phase-boundaries/report.md
+++ b/specs/bugfixes/batch-remove-shifts-phase-boundaries/report.md
@@ -1,0 +1,73 @@
+# Bugfix Report: Batch Remove Shifts Phase Boundaries
+
+**Date:** 2025-07-21
+**Status:** Fixed
+**Ticket:** T-820
+
+## Description of the Issue
+
+When running batch remove operations on a file that contains phases (H2 headers), the phase boundaries were destroyed. All phase headers were stripped from the output, and tasks that were in later phases would shift to incorrect positions.
+
+**Reproduction steps:**
+1. Create a task file with multiple phases (e.g., Planning, Implementation, Deployment)
+2. Run a batch operation with only `remove` operations (no `phase` field on any op)
+3. Observe that all `## Phase` headers are missing from the resulting file
+
+**Impact:** High — any batch remove on phased files silently destroys the phase structure, losing organizational information.
+
+## Investigation Summary
+
+- **Symptoms examined:** Phase headers disappeared after batch remove operations
+- **Code inspected:** `cmd/batch.go` (CLI entry point), `internal/task/batch.go` (ExecuteBatchWithPhases), `internal/task/operations.go` (adjustPhaseMarkersForRemoval)
+- **Hypotheses tested:** Initially investigated whether `adjustPhaseMarkersForRemoval` had incorrect math when processing multiple removes in reverse order — the math was correct. The real issue was upstream in the CLI dispatch logic.
+
+## Discovered Root Cause
+
+In `cmd/batch.go`, the `executeBatchCommand` function decided whether to use phase-aware execution based solely on whether any **operation** referenced a phase (`op.Phase != ""` or `op.Type == "add-phase"`). It did **not** check whether the **file itself** contained phases.
+
+When batch removes were submitted without a `phase` field (which is the normal case for removes), `hasPhaseOps` was `false`, so the code took the non-phase-aware path: `ParseFile` (no phase extraction) → `ExecuteBatch` (no phase preservation) → `WriteFile` (no phase headers).
+
+**Defect type:** Logic error — incomplete condition in dispatch logic
+
+**Why it occurred:** The phase-aware path was added to support adding tasks to specific phases. The condition only checked for operations that explicitly name a phase, missing the case where the file already has phases that need preserving.
+
+**Contributing factors:** The internal `ExecuteBatchWithPhases` function already had the correct guard (`len(phaseMarkers) > 0 || hasPhaseOps`), but the CLI layer short-circuited before reaching it.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/batch.go` — Always parse the file with `ParseFileWithPhases` so phase markers are detected. Use `ExecuteBatchWithPhases` when the file has phases or operations reference phases; fall back to regular `ExecuteBatch` only when neither condition is true.
+
+**Approach rationale:** This aligns the CLI dispatch logic with the guard already present inside `ExecuteBatchWithPhases`, which correctly handles both phase sources. `ParseFileWithPhases` returns an empty markers slice for non-phased files, so the fallback path is still exercised when appropriate.
+
+**Alternatives considered:**
+- Adding a separate `hasPhases` file check before the dispatch — rejected as unnecessarily complex when we can simply always parse with phases and let the existing internal guard decide.
+
+## Regression Test
+
+**Test file:** `cmd/batch_test.go`
+**Test name:** `TestBatchCommand_RemoveOnPhasedFilePreservesPhases`
+
+**What it verifies:** That batch remove operations on a phased file (without any `phase` field on the operations) preserve all phase headers and keep tasks in their correct phases.
+
+**Run command:** `go test -run TestBatchCommand_RemoveOnPhasedFilePreservesPhases -v ./cmd/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/batch.go` | Always use `ParseFileWithPhases`; dispatch to phase-aware path when file has phases |
+| `cmd/batch_test.go` | Added regression test `TestBatchCommand_RemoveOnPhasedFilePreservesPhases` |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`make test`)
+- [x] Build succeeds (`go build`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding phase-aware code paths, always check both the file's phase state AND the operation's phase references
+- The internal library already had the correct condition — the CLI layer should delegate this decision rather than duplicating it


### PR DESCRIPTION
## Summary

Batch remove operations on phased files were stripping all phase headers because `cmd/batch.go` only used phase-aware execution when an operation explicitly referenced a phase (`op.Phase` or `add-phase`). Plain removes took the non-phase path, destroying the phase structure.

## Root Cause

The dispatch logic in `executeBatchCommand` checked `hasPhaseOps` (whether any operation names a phase), but not whether the **file itself** contains phases. The internal `ExecuteBatchWithPhases` already had the correct guard (`len(phaseMarkers) > 0 || hasPhaseOps`), but the CLI layer short-circuited before reaching it.

## Fix

Always parse with `ParseFileWithPhases` so the file's own phase markers are detected. Use `ExecuteBatchWithPhases` when the file has phases or operations reference phases; fall back to regular `ExecuteBatch` only when neither condition applies.

## Changes
- `cmd/batch.go` — Restructure dispatch to always detect file phases
- `cmd/batch_test.go` — Add regression test `TestBatchCommand_RemoveOnPhasedFilePreservesPhases`
- `specs/bugfixes/batch-remove-shifts-phase-boundaries/report.md` — Bugfix report

## Testing
- Regression test confirms phase headers and task positions are preserved after batch remove
- Full test suite passes (`make test`)