### PR TITLE
Fix CI test failures (T-856, T-857, T-859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renumber Command** (T-859): `renumber` now preserves all phase markers in files with non-sequential top-level task IDs. Previously the command extracted raw file IDs to map phase positions, but `ExtractPhaseMarkers` was changed (T-742) to return sequential positional IDs instead — the mismatched lookup silently dropped later phase markers (e.g. a three-phase file would render with the second and third phase headers anchored to the wrong tasks or lost entirely)
 - **Streams Command**: `streams --available --json` (and `streams --json`) now recomputes the `available` array from the filtered `streams` list, preventing stale stream IDs from appearing in `available` after `filterEmptyStreams` or `filterAvailableStreams` removes streams
 - **Batch Command**: Batch remove operations on phased files now preserve phase boundaries; previously, removes without an explicit `phase` field bypassed phase-aware execution, stripping all phase headers from the output
 - **Next Command**: `next --phase --claim AGENT` now correctly claims all ready tasks from the next phase instead of silently ignoring `--phase` and claiming only a single task

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -19,6 +19,10 @@ func resetBatchFlags() {
 	if f := batchCmd.Flags().Lookup("input"); f != nil {
 		f.Changed = false
 	}
+	format = "table"
+	if f := rootCmd.PersistentFlags().Lookup("format"); f != nil {
+		f.Changed = false
+	}
 }
 
 func TestBatchCommand_BasicOperations(t *testing.T) {
@@ -215,6 +219,8 @@ func TestBatchCommand_ValidationFailures(t *testing.T) {
 }
 
 func TestBatchCommand_JSONOutput(t *testing.T) {
+	t.Cleanup(resetBatchFlags)
+
 	// Create temporary directory
 	tmpDir := t.TempDir()
 	taskFile := filepath.Join(tmpDir, "test_tasks.md")
@@ -609,6 +615,7 @@ func TestBatchCommand_RemoveOnPhasedFilePreservesPhases(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	resetBatchFlags()
+	t.Cleanup(resetBatchFlags)
 
 	// Batch remove tasks 1 and 3 — no phase field set on any operation
 	req := task.BatchRequest{

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/arjenschwarz/rune/internal/config"
 	"github.com/arjenschwarz/rune/internal/task"
 )
 
@@ -446,6 +449,31 @@ metadata:
 }
 
 func TestResolveFilename(t *testing.T) {
+	// Isolate from the developer's real config and git state: run in a fresh
+	// git repo with discovery disabled so "no filename provided" deterministically
+	// returns an error regardless of the host branch or surrounding filesystem.
+	config.ResetConfigCache()
+	tempDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(originalDir)
+		config.ResetConfigCache()
+	})
+
+	if err := exec.Command("git", "-C", tempDir, "init").Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	configYAML := "discovery:\n  enabled: false\n"
+	if err := os.WriteFile(filepath.Join(tempDir, ".rune.yml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
 	tests := map[string]struct {
 		args        []string
 		expectArg   bool
@@ -459,7 +487,7 @@ func TestResolveFilename(t *testing.T) {
 		"no filename provided": {
 			args:        []string{},
 			expectArg:   false,
-			expectError: true, // Will error since git discovery is disabled by default
+			expectError: true,
 		},
 	}
 

--- a/cmd/renumber.go
+++ b/cmd/renumber.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
+	"strconv"
 	"strings"
 
 	output "github.com/ArjenSchwarz/go-output/v2"
@@ -91,14 +91,7 @@ func runRenumber(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("file exceeds 10MB limit")
 	}
 
-	// Phase 2: Read file content to extract task IDs in file order (before parsing renumbers them)
-	fileContent, err := os.ReadFile(filePath)
-	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
-	}
-	fileTaskIDOrder := extractTaskIDOrder(string(fileContent))
-
-	// Phase 2.5: Parse file (note: parser renumbers tasks automatically)
+	// Phase 2: Parse file (note: parser renumbers tasks automatically)
 	taskList, phaseMarkers, err := task.ParseFileWithPhases(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse task file: %w", err)
@@ -117,8 +110,10 @@ func runRenumber(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
 
-	// Phase 5: Convert phase markers from ID-based to position-based using file task order
-	phasePositions := convertPhaseMarkersToPositions(phaseMarkers, fileTaskIDOrder)
+	// Phase 5: Convert phase markers from ID-based to position-based.
+	// ExtractPhaseMarkers returns AfterTaskID as a sequential 1-based count
+	// of preceding top-level tasks, so position is N-1.
+	phasePositions := convertPhaseMarkersToPositions(phaseMarkers)
 
 	// Phase 5.5: Renumber tasks
 	taskList.RenumberTasks()
@@ -210,61 +205,27 @@ type phasePosition struct {
 	AfterPosition int // -1 means before all tasks, 0+ means after task at that index
 }
 
-// extractTaskIDOrder extracts root-level task IDs in the order they appear in the file.
-// This is needed because the parser automatically renumbers tasks, but phase markers
-// reference the original IDs from the file.
-// Front matter is stripped first so that the extracted IDs align with what
-// ExtractPhaseMarkers sees (it also strips front matter).
-func extractTaskIDOrder(content string) []string {
-	var taskIDs []string
-	lines := strings.Split(content, "\n")
-
-	// Strip front matter to stay consistent with ExtractPhaseMarkers,
-	// which also strips front matter before scanning for task IDs.
-	lines = task.StripFrontMatterLines(lines)
-
-	taskLinePattern := regexp.MustCompile(`^- \[[ \-xX]\] (\d+(?:\.\d+)*)\. `)
-
-	for _, line := range lines {
-		if matches := taskLinePattern.FindStringSubmatch(line); len(matches) >= 2 {
-			taskID := matches[1]
-			// Only track root-level tasks (no dots in ID)
-			if !strings.Contains(taskID, ".") {
-				taskIDs = append(taskIDs, taskID)
-			}
-		}
-	}
-
-	return taskIDs
-}
-
 // convertPhaseMarkersToPositions converts phase markers from ID-based to position-based.
-// Uses fileTaskIDOrder to map original file task IDs to their position in the file.
-func convertPhaseMarkersToPositions(markers []task.PhaseMarker, fileTaskIDOrder []string) []phasePosition {
-	// Build a map from file task ID to position
-	idToPosition := make(map[string]int)
-	for i, id := range fileTaskIDOrder {
-		idToPosition[id] = i
-	}
-
+// ExtractPhaseMarkers stores AfterTaskID as a 1-based sequential count of preceding
+// top-level tasks (e.g. "3" means the marker appears after the 3rd top-level task),
+// so the corresponding position is N-1. AfterTaskID="" means before all tasks.
+func convertPhaseMarkersToPositions(markers []task.PhaseMarker) []phasePosition {
 	positions := make([]phasePosition, len(markers))
 
 	for i, marker := range markers {
 		positions[i].Name = marker.Name
 
 		if marker.AfterTaskID == "" {
-			// Phase at the beginning
 			positions[i].AfterPosition = -1
 			continue
 		}
 
-		// Look up the position where this task ID appeared in the file
-		if pos, exists := idToPosition[marker.AfterTaskID]; exists {
-			positions[i].AfterPosition = pos
-		} else {
-			// Task ID not found, default to -1 (shouldn't happen with valid files)
+		n, err := strconv.Atoi(marker.AfterTaskID)
+		if err != nil || n < 1 {
 			positions[i].AfterPosition = -1
+			continue
 		}
+		positions[i].AfterPosition = n - 1
 	}
 
 	return positions

--- a/cmd/renumber_test.go
+++ b/cmd/renumber_test.go
@@ -342,61 +342,65 @@ func TestRenumberValidationOrder(t *testing.T) {
 	}
 }
 
-// TestConvertPhaseMarkersToPositions tests the phase marker to position conversion
+// TestConvertPhaseMarkersToPositions tests the phase marker to position conversion.
+// ExtractPhaseMarkers stores AfterTaskID as a 1-based sequential count of preceding
+// top-level tasks (T-742), so position is N-1.
 func TestConvertPhaseMarkersToPositions(t *testing.T) {
 	tests := map[string]struct {
 		inputMarkers      []task.PhaseMarker
-		fileTaskIDOrder   []string
 		expectedPositions []phasePosition
 	}{
 		"empty markers": {
 			inputMarkers:      []task.PhaseMarker{},
-			fileTaskIDOrder:   []string{"1", "2", "3"},
 			expectedPositions: []phasePosition{},
 		},
 		"phase at beginning": {
 			inputMarkers: []task.PhaseMarker{
 				{Name: "Phase 1", AfterTaskID: ""},
 			},
-			fileTaskIDOrder: []string{"1", "2", "3"},
 			expectedPositions: []phasePosition{
 				{Name: "Phase 1", AfterPosition: -1},
 			},
 		},
-		"phase after task in order": {
+		"phase after first top-level task": {
 			inputMarkers: []task.PhaseMarker{
-				{Name: "Phase 1", AfterTaskID: "2"},
+				{Name: "Phase 1", AfterTaskID: "1"},
 			},
-			fileTaskIDOrder: []string{"1", "2", "3"},
 			expectedPositions: []phasePosition{
-				{Name: "Phase 1", AfterPosition: 1}, // Task 2 is at position 1
+				{Name: "Phase 1", AfterPosition: 0},
 			},
 		},
-		"phase after out of order task": {
+		"phase after third top-level task": {
 			inputMarkers: []task.PhaseMarker{
-				{Name: "Phase 1", AfterTaskID: "7"},
+				{Name: "Phase 1", AfterTaskID: "3"},
 			},
-			fileTaskIDOrder: []string{"1", "2", "6", "7", "3", "4", "5"},
 			expectedPositions: []phasePosition{
-				{Name: "Phase 1", AfterPosition: 3}, // Task 7 is at position 3 in file
+				{Name: "Phase 1", AfterPosition: 2},
 			},
 		},
 		"multiple phases": {
 			inputMarkers: []task.PhaseMarker{
-				{Name: "Phase 1", AfterTaskID: "2"},
-				{Name: "Phase 2", AfterTaskID: "7"},
+				{Name: "Phase 1", AfterTaskID: "1"},
+				{Name: "Phase 2", AfterTaskID: "3"},
 			},
-			fileTaskIDOrder: []string{"1", "2", "6", "7", "3", "4", "5"},
 			expectedPositions: []phasePosition{
-				{Name: "Phase 1", AfterPosition: 1}, // Task 2 at position 1
-				{Name: "Phase 2", AfterPosition: 3}, // Task 7 at position 3
+				{Name: "Phase 1", AfterPosition: 0},
+				{Name: "Phase 2", AfterPosition: 2},
+			},
+		},
+		"non-numeric AfterTaskID falls back to start": {
+			inputMarkers: []task.PhaseMarker{
+				{Name: "Phase 1", AfterTaskID: "abc"},
+			},
+			expectedPositions: []phasePosition{
+				{Name: "Phase 1", AfterPosition: -1},
 			},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := convertPhaseMarkersToPositions(tc.inputMarkers, tc.fileTaskIDOrder)
+			result := convertPhaseMarkersToPositions(tc.inputMarkers)
 
 			if len(result) != len(tc.expectedPositions) {
 				t.Fatalf("Expected %d positions, got %d", len(tc.expectedPositions), len(result))
@@ -470,71 +474,6 @@ func TestGetRootTaskID(t *testing.T) {
 			result := getRootTaskID(tc.taskID)
 			if result != tc.expected {
 				t.Errorf("Expected %s, got %s", tc.expected, result)
-			}
-		})
-	}
-}
-
-// TestExtractTaskIDOrder tests the extractTaskIDOrder function
-func TestExtractTaskIDOrder(t *testing.T) {
-	tests := map[string]struct {
-		content  string
-		expected []string
-	}{
-		"sequential tasks": {
-			content: `# Test
-- [ ] 1. First
-- [ ] 2. Second
-- [ ] 3. Third`,
-			expected: []string{"1", "2", "3"},
-		},
-		"out of order tasks": {
-			content: `# Test
-- [ ] 1. First
-- [ ] 2. Second
-- [ ] 6. Sixth
-- [ ] 7. Seventh
-- [ ] 3. Third`,
-			expected: []string{"1", "2", "6", "7", "3"},
-		},
-		"tasks with subtasks": {
-			content: `# Test
-- [ ] 1. First
-  - [ ] 1.1. Subtask
-- [ ] 2. Second`,
-			expected: []string{"1", "2"}, // Only root tasks
-		},
-		"mixed with phases": {
-			content: `# Test
-- [ ] 1. First
-## Phase 1
-- [ ] 2. Second`,
-			expected: []string{"1", "2"},
-		},
-		"with front matter": {
-			content: `---
-references:
-  - requirements.md
----
-# Test
-- [ ] 1. First
-- [ ] 2. Second`,
-			expected: []string{"1", "2"},
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := extractTaskIDOrder(tc.content)
-
-			if len(result) != len(tc.expected) {
-				t.Fatalf("Expected %d IDs, got %d", len(tc.expected), len(result))
-			}
-
-			for i, expected := range tc.expected {
-				if result[i] != expected {
-					t.Errorf("Position %d: expected ID '%s', got '%s'", i, expected, result[i])
-				}
 			}
 		})
 	}

--- a/docs/agent-notes/testing.md
+++ b/docs/agent-notes/testing.md
@@ -2,9 +2,16 @@
 
 ## Shared Command State
 
-Command tests often call `runX` helpers directly and share package-level globals such as `format` and `dryRun`. Tests that expect default table output must set and restore `format` explicitly, otherwise earlier JSON/markdown tests can leak state. T-857 tracks the current `TestRunCompleteDryRun` failure.
+Command tests share package-level globals from `cmd/root.go` (`format`, `dryRun`, `verbose`) because Cobra binds persistent flags to those variables. Once a test calls `rootCmd.Execute()` with `--format json`, the global stays as `"json"` for every subsequent test in the process.
 
-## Current Known Test Failures
+`resetBatchFlags()` in `cmd/batch_test.go` resets both `batchInput` and `format` (back to `"table"`) along with the `Changed` bits on the corresponding flags. Any batch test that uses `--format json` should register `t.Cleanup(resetBatchFlags)` so the global doesn't leak. Tests that depend on the default `format == "table"` (e.g. `TestRunCompleteDryRun`) get protected indirectly by that cleanup.
 
-- T-856: `internal/task/phase_test.go` has a stale two-argument call to `RenderMarkdownWithPhases`; the production function now requires a `phaseSource *TaskList`.
-- T-859: `cmd.TestRenumberPreservesAllPhaseMarkers` shows `runRenumber` misplacing phase markers for files with gapped/non-sequential top-level IDs. `ExtractPhaseMarkers` already returns sequential IDs, but `cmd/renumber.go` still maps markers through raw file task IDs.
+## Config / Git Discovery in Tests
+
+`config.LoadConfig` caches the loaded config under a `sync.Once`, so the first call wins for the lifetime of the test process. `internal/config` exposes `ResetConfigCache()` for tests that need to install a different config or chdir into a different repo.
+
+`config.DiscoverFileFromBranch` strips the first path segment of the branch name (e.g. `T-824/homebrew-install` → `homebrew-install`) before substituting `{branch}` into the template. Tests that expect discovery to fail must isolate themselves: chdir into a fresh git repo with a `.rune.yml` that sets `discovery.enabled: false`. Otherwise the test outcome depends on the developer's current branch name and which `specs/<name>/tasks.md` files happen to exist.
+
+## Renumber and Phase Markers
+
+`task.ExtractPhaseMarkers` (T-742) stores `AfterTaskID` as a 1-based sequential count of preceding top-level tasks, NOT as the literal IDs from the markdown. Anything in `cmd/renumber.go` that maps phase markers to positions must convert that count directly (`position = N - 1`); attempting to look up the value in a map of raw file IDs will silently fail for any non-trivial file (T-859 was caused by that mismatch).

--- a/internal/task/phase_test.go
+++ b/internal/task/phase_test.go
@@ -1550,7 +1550,7 @@ func TestRenderMarkdownWithPhases_NonSequentialIDs(t *testing.T) {
 		{Name: "Phase B", AfterTaskID: "2"},
 	}
 
-	got := string(RenderMarkdownWithPhases(tl, markers))
+	got := string(RenderMarkdownWithPhases(tl, markers, nil))
 	want := `# Non-Sequential Project
 
 ## Phase A


### PR DESCRIPTION
## Summary

Fix the four pre-existing test failures that were red on main:

- **T-859 (code bug)** — `cmd/renumber.go` looked up `marker.AfterTaskID` in a map keyed by raw file IDs, but `ExtractPhaseMarkers` was changed in T-742 to return `AfterTaskID` as a 1-based sequential count of preceding top-level tasks. The mismatched lookup silently dropped later phase markers in files with non-sequential top-level IDs (multi-phase + gapped IDs would render with wrong anchors or lost headers). Replaced `extractTaskIDOrder` + the `idToPosition` map with a direct `N → N-1` conversion in `convertPhaseMarkersToPositions`, dropped the dead helper, and rewrote its unit test for the new contract.
- **T-856 (test bug)** — `internal/task/phase_test.go:1553` still called `RenderMarkdownWithPhases` with two arguments after T-698 added a `phaseSource *TaskList` parameter. All other call sites pass `nil`; the regression test was just missed.
- **T-857 (test bug)** — `resetBatchFlags()` reset `batchInput` but not the `format` global. Two batch tests (`TestBatchCommand_JSONOutput`, `TestBatchCommand_RemoveOnPhasedFilePreservesPhases`) called `rootCmd.Execute()` with `--format json`, leaving `format = "json"` for every subsequent test. `TestRunCompleteDryRun` then failed because it depends on the default `"table"` format. Reset `format` and the format flag's `Changed` bit in `resetBatchFlags`, and register `t.Cleanup(resetBatchFlags)` on the two leaking tests.
- **TestResolveFilename (test bug)** — the "no filename provided" subtest claimed discovery is "disabled by default", but `Discovery.Enabled` defaults to `true`. The test passed only when the host branch + filesystem produced no discovery match; on CI for branches like `T-824/homebrew-install` (with `specs/homebrew-install/tasks.md` present), discovery succeeded and the test failed. Now isolated in a fresh git repo with `discovery.enabled: false`.

Also updates `docs/agent-notes/testing.md` with the new `resetBatchFlags` contract, the discovery-isolation requirement, and a note on the `ExtractPhaseMarkers` / `renumber.go` invariant.

## Test plan

- [x] `make check` (fmt + lint + unit tests) passes locally
- [x] `make test-integration` passes locally
- [ ] CI green on the PR (this is the point)